### PR TITLE
Merge with master.

### DIFF
--- a/docs/language-reference.rst
+++ b/docs/language-reference.rst
@@ -5,8 +5,9 @@ Language Reference
 
 The builtin types in Futhark are ``int``, ``real``, ``bool`` and
 ``char``, as well as their combination in tuples and arrays.  An
-``int`` is currently 32 bits and ``real`` is a double-precision double
-(64 bits).  This is likely to become configurable in the future.
+``int`` is currently 32 bits and ``real`` is by default a
+double-precision float (64 bits).  Some compiler frontends permit
+configuration of whether ``real`` maps to a 32-bit or 64-bit float.
 
 The following list describes every syntactical language construct in
 the language.  For convenience, we will sometimes talk of expressions

--- a/futhark.cabal
+++ b/futhark.cabal
@@ -71,9 +71,14 @@ Library
                    Futhark.CodeGen.Backends.SequentialPython
                    Futhark.CodeGen.Backends.SimpleRepresentation
                    Futhark.CodeGen.ImpCode
+                   Futhark.CodeGen.ImpCode.Kernels
+                   Futhark.CodeGen.ImpCode.OpenCL
+                   Futhark.CodeGen.ImpCode.Sequential
                    Futhark.CodeGen.ImpGen
-                   Futhark.CodeGen.KernelImp
-                   Futhark.CodeGen.KernelImpGen
+                   Futhark.CodeGen.ImpGen.Kernels
+                   Futhark.CodeGen.ImpGen.Kernels.ToOpenCL
+                   Futhark.CodeGen.ImpGen.OpenCL
+                   Futhark.CodeGen.ImpGen.Sequential
                    Futhark.CodeGen.OpenCL.Kernels
                    Futhark.CodeGen.SetDefaultSpace
                    Futhark.Compiler

--- a/src/Futhark/Actions.hs
+++ b/src/Futhark/Actions.hs
@@ -23,8 +23,8 @@ import Futhark.Representation.AST
 import Futhark.Representation.Basic (Basic)
 import Futhark.Representation.ExplicitMemory (ExplicitMemory)
 import Futhark.Interpreter
-import qualified Futhark.CodeGen.ImpGen as ImpGen
-import qualified Futhark.CodeGen.KernelImpGen as KernelImpGen
+import qualified Futhark.CodeGen.ImpGen.Sequential as ImpGenSequential
+import qualified Futhark.CodeGen.ImpGen.Kernels as ImpGenKernels
 import qualified Futhark.CodeGen.Backends.SequentialC as SequentialC
 
 printAction :: PrettyLore lore => Action lore
@@ -61,14 +61,14 @@ impCodeGenAction :: Action ExplicitMemory
 impCodeGenAction =
   Action { actionName = "Compile imperative"
          , actionDescription = "Translate program into imperative IL and write it on standard output."
-         , actionProcedure = liftIO . either error (putStrLn . pretty) . ImpGen.compileProgSimply
+         , actionProcedure = liftIO . either error (putStrLn . pretty) . ImpGenSequential.compileProg
          }
 
 kernelImpCodeGenAction :: Action ExplicitMemory
 kernelImpCodeGenAction =
   Action { actionName = "Compile imperative kernels"
          , actionDescription = "Translate program into imperative IL with kernels and write it on standard output."
-         , actionProcedure = liftIO . either error (putStrLn . pretty) . KernelImpGen.compileProg
+         , actionProcedure = liftIO . either error (putStrLn . pretty) . ImpGenKernels.compileProg
          }
 
 interpret :: (Show error, PrettyLore lore) =>

--- a/src/Futhark/CodeGen/Backends/COpenCL.hs
+++ b/src/Futhark/CodeGen/Backends/COpenCL.hs
@@ -5,10 +5,6 @@ module Futhark.CodeGen.Backends.COpenCL
 
 import Control.Applicative
 import Control.Monad
-import Control.Monad.Writer
-import Control.Monad.State
-import Data.Traversable hiding (forM, mapM, sequence)
-import qualified Data.HashSet as HS
 import Data.List
 
 import Prelude
@@ -16,32 +12,28 @@ import Prelude
 import qualified Language.C.Syntax as C
 import qualified Language.C.Quote.OpenCL as C
 
-import qualified Futhark.CodeGen.OpenCL.Kernels as Kernels
+import Futhark.Representation.ExplicitMemory (Prog)
 import Futhark.CodeGen.Backends.COpenCL.Boilerplate
-import Futhark.Representation.ExplicitMemory (Prog, pretty)
 import qualified Futhark.CodeGen.Backends.GenericC as GenericC
 import Futhark.CodeGen.Backends.GenericC.Options
-import Futhark.CodeGen.Backends.SimpleRepresentation
-import Futhark.CodeGen.KernelImp
-import qualified Futhark.CodeGen.KernelImpGen as KernelImpGen
+import Futhark.CodeGen.ImpCode.OpenCL
+import qualified Futhark.CodeGen.ImpGen.OpenCL as ImpGen
 import Futhark.MonadFreshNames
 
 compileProg :: Prog -> Either String String
 compileProg prog = do
-  prog' <- KernelImpGen.compileProg prog
+  Program opencl_code kernel_names prog' <- ImpGen.compileProg prog
   let header = unlines [ "#include <CL/cl.h>\n"
                        , "#define FUT_KERNEL(s) #s"
                        , "#define OPENCL_SUCCEED(e) opencl_succeed(e, #e, __FILE__, __LINE__)"
                        , blockDimPragma
                        ]
-  (kernels, requirements) <- compileKernels $ getKernels prog'
-  let kernel_names = map fst kernels
   return $
     header ++
     GenericC.compileProg operations ()
-    (openClDecls kernel_names $ openClProgram kernels requirements)
+    (openClDecls kernel_names opencl_code)
     openClInit (openClReport kernel_names) options prog'
-  where operations :: GenericC.Operations CallKernel ()
+  where operations :: GenericC.Operations OpenCL ()
         operations = GenericC.Operations
                      { GenericC.opsCompiler = callKernel
                      , GenericC.opsWriteScalar = writeOpenCLScalar
@@ -63,7 +55,7 @@ compileProg prog = do
                            }
                   ]
 
-writeOpenCLScalar :: GenericC.WriteScalar CallKernel ()
+writeOpenCLScalar :: GenericC.WriteScalar OpenCL ()
 writeOpenCLScalar mem i t "device" val = do
   val' <- newVName "write_tmp"
   GenericC.stm [C.cstm|{
@@ -78,7 +70,7 @@ writeOpenCLScalar mem i t "device" val = do
 writeOpenCLScalar _ _ _ space _ =
   fail $ "Cannot write to '" ++ space ++ "' memory space."
 
-readOpenCLScalar :: GenericC.ReadScalar CallKernel ()
+readOpenCLScalar :: GenericC.ReadScalar OpenCL ()
 readOpenCLScalar mem i t "device" = do
   val <- newVName "read_res"
   GenericC.decl [C.cdecl|$ty:t $id:val;|]
@@ -94,7 +86,7 @@ readOpenCLScalar mem i t "device" = do
 readOpenCLScalar _ _ _ space =
   fail $ "Cannot read from '" ++ space ++ "' memory space."
 
-allocateOpenCLBuffer :: GenericC.Allocate CallKernel ()
+allocateOpenCLBuffer :: GenericC.Allocate OpenCL ()
 allocateOpenCLBuffer mem size "device" = do
 
   errorname <- newVName "clCreateBuffer_succeeded"
@@ -114,7 +106,7 @@ allocateOpenCLBuffer mem size "device" = do
 allocateOpenCLBuffer _ _ space =
   fail $ "Cannot allocate in '" ++ space ++ "' space"
 
-copyOpenCLMemory :: GenericC.Copy CallKernel ()
+copyOpenCLMemory :: GenericC.Copy OpenCL ()
 -- The read/write/copy-buffer functions fail if the given offset is
 -- out of bounds, even if asked to read zero bytes.  We protect with a
 -- branch to avoid this.
@@ -157,99 +149,40 @@ copyOpenCLMemory destmem destidx (Space "device") srcmem srcidx (Space "device")
 copyOpenCLMemory _ _ destspace _ _ srcspace _ =
   error $ "Cannot copy to " ++ show destspace ++ " from " ++ show srcspace
 
-openclMemoryType :: GenericC.MemoryType CallKernel ()
+openclMemoryType :: GenericC.MemoryType OpenCL ()
 openclMemoryType "device" = pure [C.cty|typename cl_mem|]
 openclMemoryType "local" = pure [C.cty|unsigned char|] -- dummy type
 openclMemoryType space =
   fail $ "OpenCL backend does not support '" ++ space ++ "' memory space."
 
-callKernel :: GenericC.OpCompiler CallKernel ()
-callKernel (Kernel kernel) = do
-  zipWithM_ mkBuffer [(0::Int)..] $ kernelUses kernel
-  let kernel_size = GenericC.dimSizeToExp $ kernelSize kernel
-
-  launchKernel kernel_name [kernel_size] Nothing
+callKernel :: GenericC.OpCompiler OpenCL ()
+callKernel (LaunchKernel name args kernel_size workgroup_size) = do
+  zipWithM_ setKernelArg [(0::Int)..] args
+  kernel_size' <- mapM GenericC.compileExp kernel_size
+  workgroup_size' <- case workgroup_size of
+    Nothing -> return Nothing
+    Just es -> Just <$> mapM GenericC.compileExp es
+  launchKernel name kernel_size' workgroup_size'
   return GenericC.Done
-  where mkBuffer i (MemoryUse mem _) =
-          GenericC.stm [C.cstm|{
-            assert(clSetKernelArg($id:kernel_name, $int:i, sizeof($id:mem), &$id:mem)
+  where setKernelArg i (ValueArg e bt) = do
+          v <- GenericC.compileExpToName "kernel_arg" bt e
+          GenericC.stm [C.cstm|
+            assert(clSetKernelArg($id:name, $int:i, sizeof($id:v), &$id:v)
                    == CL_SUCCESS);
-            }|]
+          |]
 
-        mkBuffer i (ScalarUse hostvar _) =
-          GenericC.stm [C.cstm|{
-            assert(clSetKernelArg($id:kernel_name, $int:i, sizeof($id:hostvar), &$id:hostvar)
+        setKernelArg i (MemArg v) =
+          GenericC.stm [C.cstm|
+            assert(clSetKernelArg($id:name, $int:i, sizeof($id:v), &$id:v)
                    == CL_SUCCESS);
-          }|]
+          |]
 
-        kernel_name = mapKernelName kernel
-
-callKernel (Reduce kernel) = do
-  zipWithM_ mkLocalMemory [(0::Int)..] $ reductionThreadLocalMemory kernel
-  zipWithM_ mkBuffer [num_local_mems..] $ reductionUses kernel
-
-  launchKernel kernel_name [kernel_size] (Just [workgroup_size])
-  return GenericC.Done
-  where num_local_mems = length $ reductionThreadLocalMemory kernel
-        kernel_name = reduceKernelName kernel
-        workgroup_size = GenericC.dimSizeToExp $ reductionGroupSize kernel
-        num_workgroups = GenericC.dimSizeToExp $ reductionNumGroups kernel
-        kernel_size = [C.cexp|$exp:workgroup_size * $exp:num_workgroups|]
-
-        mkLocalMemory i (_, num_bytes) =
-          GenericC.stm [C.cstm|{
-                            assert(clSetKernelArg($id:kernel_name, $int:i,
-                                                  $exp:num_bytes',
-                                                  NULL)
-                                   == CL_SUCCESS);
-                        }|]
-          where num_bytes' = GenericC.dimSizeToExp num_bytes
-
-        mkBuffer i (MemoryUse mem _) =
-          GenericC.stm [C.cstm|{
-            assert(clSetKernelArg($id:kernel_name, $int:i, sizeof($id:mem), &$id:mem)
+        setKernelArg i (SharedMemoryArg num_bytes) = do
+          num_bytes' <- GenericC.compileExp $ innerExp num_bytes
+          GenericC.stm [C.cstm|
+            assert(clSetKernelArg($id:name, $int:i, $exp:num_bytes', NULL)
                    == CL_SUCCESS);
-            }|]
-
-        mkBuffer i (ScalarUse hostvar _) =
-          GenericC.stm [C.cstm|{
-            assert(clSetKernelArg($id:kernel_name, $int:i, sizeof($id:hostvar), &$id:hostvar)
-                   == CL_SUCCESS);
-          }|]
-
-callKernel kernel@(MapTranspose bt destmem destoffset srcmem srcoffset num_arrays x_elems y_elems) = do
-  destoffset' <- GenericC.compileExpToName "destoffset" Int destoffset
-  srcoffset' <- GenericC.compileExpToName "srcoffset" Int  srcoffset
-  x_elems' <- GenericC.compileExpToName "x_elems" Int x_elems
-  y_elems' <- GenericC.compileExpToName "y_elems" Int y_elems
-  GenericC.stm [C.cstm|{
-    assert(clSetKernelArg($id:kernel_name, 0, sizeof(cl_mem), &$id:destmem)
-           == CL_SUCCESS);
-    assert(clSetKernelArg($id:kernel_name, 1, sizeof(int), &$id:destoffset')
-           == CL_SUCCESS);
-    assert(clSetKernelArg($id:kernel_name, 2, sizeof(cl_mem), &$id:srcmem)
-           == CL_SUCCESS);
-    assert(clSetKernelArg($id:kernel_name, 3, sizeof(int), &$id:srcoffset')
-           == CL_SUCCESS);
-    assert(clSetKernelArg($id:kernel_name, 4, sizeof(int), &$id:x_elems')
-           == CL_SUCCESS);
-    assert(clSetKernelArg($id:kernel_name, 5, sizeof(int), &$id:y_elems')
-           == CL_SUCCESS);
-    assert(clSetKernelArg($id:kernel_name, 6, (FUT_BLOCK_DIM + 1) * FUT_BLOCK_DIM * sizeof($ty:ty), NULL)
-           == CL_SUCCESS);
-  }|]
-  kernel_size <- sequence [roundedToBlockSize <$> GenericC.compileExp x_elems,
-                           roundedToBlockSize <$> GenericC.compileExp y_elems,
-                           GenericC.compileExp num_arrays]
-  let workgroup_size = Just [[C.cexp|FUT_BLOCK_DIM|], [C.cexp|FUT_BLOCK_DIM|], [C.cexp|1|]]
-  launchKernel kernel_name kernel_size workgroup_size
-  return GenericC.Done
-  where kernel_name = kernelName kernel
-        ty = GenericC.scalarTypeToCType bt
-        roundedToBlockSize e =
-          [C.cexp|$exp:e +
-                   (FUT_BLOCK_DIM - $exp:e % FUT_BLOCK_DIM) % FUT_BLOCK_DIM
-           |]
+            |]
 
 launchKernel :: C.ToExp a =>
                 String -> [a] -> Maybe [a] -> GenericC.CompilerM op s ()
@@ -306,225 +239,5 @@ launchKernel kernel_name kernel_dims workgroup_dims = do
         printKernelDim global_work_size i =
           [[C.cstm|fprintf(stderr, "%zu", $id:global_work_size[$int:i]);|]]
 
-pointerQuals ::  Monad m => String -> m [C.TypeQual]
-pointerQuals "global"     = return [C.ctyquals|__global|]
-pointerQuals "local"      = return [C.ctyquals|__local volatile|]
-pointerQuals "private"    = return [C.ctyquals|__private|]
-pointerQuals "constant"   = return [C.ctyquals|__constant|]
-pointerQuals "write_only" = return [C.ctyquals|__write_only|]
-pointerQuals "read_only"  = return [C.ctyquals|__read_only|]
-pointerQuals "kernel"     = return [C.ctyquals|__kernel|]
-pointerQuals s            = fail $ "'" ++ s ++ "' is not an OpenCL kernel address space."
-
-type UsedFunctions = [(String,C.Func)] -- The ordering is important!
-
-data OpenClRequirements =
-  OpenClRequirements { _kernelUsedFunctions :: UsedFunctions
-                     , _kernelPragmas :: [String]
-                     }
-
-instance Monoid OpenClRequirements where
-  mempty =
-    OpenClRequirements [] []
-
-  OpenClRequirements used1 pragmas1 `mappend` OpenClRequirements used2 pragmas2 =
-    OpenClRequirements (nubBy cmpFst $ used1 <> used2) (nub $ pragmas1 ++ pragmas2)
-    where cmpFst (x, _) (y, _) = x == y
-
-inKernelOperations :: GenericC.Operations InKernel UsedFunctions
-inKernelOperations = GenericC.Operations
-                     { GenericC.opsCompiler = kernelOps
-                     , GenericC.opsMemoryType = kernelMemoryType
-                     , GenericC.opsWriteScalar = GenericC.writeScalarPointerWithQuals pointerQuals
-                     , GenericC.opsReadScalar = GenericC.readScalarPointerWithQuals pointerQuals
-                     , GenericC.opsAllocate = cannotAllocate
-                     , GenericC.opsCopy = copyInKernel
-                     }
-  where kernelOps :: GenericC.OpCompiler InKernel UsedFunctions
-        kernelOps (GetGroupId v i) = do
-          GenericC.stm [C.cstm|$id:v = get_group_id($int:i);|]
-          return GenericC.Done
-        kernelOps (GetLocalId v i) = do
-          GenericC.stm [C.cstm|$id:v = get_local_id($int:i);|]
-          return GenericC.Done
-        kernelOps (GetLocalSize v i) = do
-          GenericC.stm [C.cstm|$id:v = get_local_size($int:i);|]
-          return GenericC.Done
-        kernelOps (GetGlobalId v i) = do
-          GenericC.stm [C.cstm|$id:v = get_global_id($int:i);|]
-          return GenericC.Done
-        kernelOps (GetGlobalSize v i) = do
-          GenericC.stm [C.cstm|$id:v = get_global_size($int:i);|]
-          return GenericC.Done
-
-        cannotAllocate :: GenericC.Allocate InKernel UsedFunctions
-        cannotAllocate _ =
-          fail "Cannot allocate memory in kernel"
-
-        copyInKernel :: GenericC.Copy InKernel UsedFunctions
-        copyInKernel _ _ _ _ _ _ _ =
-          fail $ "Cannot bulk copy in kernel."
-
-        kernelMemoryType space = do
-          quals <- pointerQuals space
-          return [C.cty|$tyquals:quals $ty:defaultMemBlockType|]
-
-compileKernels :: [CallKernel] -> Either String ([(String, C.Func)], OpenClRequirements)
-compileKernels kernels = do
-  (funcs, reqs) <- unzip <$> mapM compileKernel kernels
-  return (concat funcs, mconcat reqs)
-
-compileKernel :: CallKernel -> Either String ([(String, C.Func)], OpenClRequirements)
-compileKernel (Kernel kernel) =
-  let (funbody, s) =
-        GenericC.runCompilerM (Program []) inKernelOperations blankNameSource mempty $
-        GenericC.collect $ GenericC.compileCode $ kernelBody kernel
-
-      used_funs = GenericC.compUserState s
-
-      params = map useAsParam $ kernelUses kernel
-
-      kernel_funs = functionsCalled $ kernelBody kernel
-
-  in Right ([(mapKernelName kernel,
-             [C.cfun|__kernel void $id:(mapKernelName kernel) ($params:params) {
-                 const uint $id:(kernelThreadNum kernel) = get_global_id(0);
-                 $items:funbody
-             }|])],
-            OpenClRequirements (used_funs ++ requiredFunctions kernel_funs) [])
-
-compileKernel (Reduce kernel) =
-  let ((kernel_prologue, fold_body, red_body,
-        write_fold_result, write_final_result), s) =
-        GenericC.runCompilerM (Program []) inKernelOperations blankNameSource mempty $ do
-          kernel_prologue_ <-
-            GenericC.collect $ GenericC.compileCode $ reductionPrologue kernel
-          fold_body_ <-
-            GenericC.collect $ GenericC.compileCode $ reductionFoldOperation kernel
-          red_body_ <-
-            GenericC.collect $ GenericC.compileCode $ reductionReduceOperation kernel
-          write_fold_result_ <-
-            GenericC.collect $ GenericC.compileCode $ reductionWriteFoldResult kernel
-
-          write_final_result_ <-
-            GenericC.collect $ GenericC.compileCode $ reductionWriteFinalResult kernel
-
-          return (kernel_prologue_, fold_body_, red_body_,
-                  write_fold_result_, write_final_result_)
-
-      used_funs = GenericC.compUserState s
-
-      use_params = map useAsParam $ reductionUses kernel
-
-      kernel_funs = functionsCalled (reductionReduceOperation kernel) <>
-                    functionsCalled (reductionFoldOperation kernel)
-
-      local_memory_params =
-        flip evalState (blankNameSource :: VNameSource) $
-        mapM prepareLocalMemory $ reductionThreadLocalMemory kernel
-
-      prologue = kernel_prologue
-
-      opencl_kernel =
-        Kernels.reduce Kernels.Reduction
-         { Kernels.reductionKernelName =
-            reduceKernelName kernel
-         , Kernels.reductionOffsetName =
-             textual $ reductionOffsetName kernel
-         , Kernels.reductionInputArrayIndexName =
-             textual $ reductionKernelName kernel
-
-         , Kernels.reductionPrologue = prologue
-         , Kernels.reductionFoldOperation = fold_body
-         , Kernels.reductionWriteFoldResult = write_fold_result
-         , Kernels.reductionReduceOperation = red_body
-         , Kernels.reductionWriteFinalResult = write_final_result
-
-         , Kernels.reductionKernelArgs =
-             local_memory_params ++ use_params
-         }
-
-  in Right ([(reduceKernelName kernel, opencl_kernel)],
-            OpenClRequirements (used_funs ++ requiredFunctions kernel_funs) [])
-  where prepareLocalMemory (mem, _) =
-          return ([C.cparam|__local volatile unsigned char* restrict $id:mem|])
-
-compileKernel kernel@(MapTranspose bt _ _ _ _ _ _ _) =
-  Right ([(kernelName kernel, Kernels.mapTranspose (kernelName kernel) ty)],
-         mempty)
-  where ty = GenericC.scalarTypeToCType bt
-
-useAsParam :: KernelUse -> C.Param
-useAsParam (ScalarUse name bt) =
-  let ctp = GenericC.scalarTypeToCType bt
-  in [C.cparam|$ty:ctp $id:name|]
-useAsParam (MemoryUse name _) =
-  [C.cparam|__global unsigned char *$id:name|]
-
-requiredFunctions :: HS.HashSet Name -> [(String, C.Func)]
-requiredFunctions kernel_funs =
-  let used_in_kernel = (`HS.member` kernel_funs) . nameFromString . fst
-      funs32_used = filter used_in_kernel funs32
-      funs64_used = filter used_in_kernel funs64
-
-      funs32 = [("toFloat32", c_toFloat32),
-                ("trunc32", c_trunc32),
-                ("log32", c_log32),
-                ("sqrt32", c_sqrt32),
-                ("exp32", c_exp32)]
-
-      funs64 = [("toFloat64", c_toFloat64),
-                ("trunc64", c_trunc64),
-                ("log64", c_log64),
-                ("sqrt64", c_sqrt64),
-                ("exp64", c_exp64)]
-  in funs32_used ++ funs64_used
-
-openClProgramHeader :: OpenClRequirements -> [C.Definition]
-openClProgramHeader (OpenClRequirements used_funs pragmas) =
-  [ [C.cedecl|$esc:pragma|] | pragma <- pragmas ] ++
-  [ [C.cedecl|$func:used_fun|] | (_, used_fun) <- used_funs ]
-
-openClProgram :: [(String, C.Func)] -> OpenClRequirements -> [C.Definition]
-openClProgram kernels requirements =
-  [C.cunit|
-// Program header and utility functions
-   $edecls:header
-
-// Kernel definitions
-   $edecls:funcs
-          |]
-  where header =
-          openClProgramHeader requirements
-        funcs =
-          [[C.cedecl|$func:kernel_func|] |
-           (_, kernel_func) <- kernels ]
-
-
-mapKernelName :: MapKernel -> String
-mapKernelName = ("map_kernel_"++) . show . baseTag . kernelThreadNum
-
-reduceKernelName :: ReduceKernel -> String
-reduceKernelName = ("red_kernel_"++) . show . baseTag . reductionKernelName
-
-kernelName :: CallKernel -> String
-kernelName (Kernel k) =
-  mapKernelName k
-kernelName (Reduce k) =
-  reduceKernelName k
-kernelName (MapTranspose bt _ _ _ _ _ _ _) =
-  "fut_kernel_map_transpose_" ++ pretty bt
-
-getKernels :: Program -> [CallKernel]
-getKernels = nubBy sameKernel . execWriter . traverse getFunKernels
-  where getFunKernels kernel =
-          tell [kernel] >> return kernel
-        sameKernel (MapTranspose bt1 _ _ _ _ _ _ _) (MapTranspose bt2 _ _ _ _ _ _ _) =
-          bt1 == bt2
-        sameKernel _ _ = False
-
-blockDim :: Int
-blockDim = 16
-
 blockDimPragma :: String
-blockDimPragma = "#define FUT_BLOCK_DIM " ++ show blockDim
+blockDimPragma = "#define FUT_BLOCK_DIM " ++ show (transposeBlockDim :: Int)

--- a/src/Futhark/CodeGen/Backends/COpenCL/Boilerplate.hs
+++ b/src/Futhark/CodeGen/Backends/COpenCL/Boilerplate.hs
@@ -7,14 +7,13 @@ module Futhark.CodeGen.Backends.COpenCL.Boilerplate
 
 import qualified Language.C.Syntax as C
 import qualified Language.C.Quote.OpenCL as C
-import Futhark.Util.Pretty
 
-openClDecls :: [String] -> [C.Definition] -> [C.Definition]
+openClDecls :: [String] -> String -> [C.Definition]
 openClDecls kernel_names opencl_program =
   kernelDeclarations ++ openclBoilerplate
   where kernelDeclarations =
-          [C.cedecl|$esc:("static const char fut_opencl_src[] = FUT_KERNEL(\n"++
-                         pretty opencl_program ++
+          [C.cedecl|$esc:("static const char fut_opencl_src[] = FUT_KERNEL(\n" ++
+                         opencl_program ++
                          ");")|] :
           concat
           [ [ [C.cedecl|static typename cl_kernel $id:name;|]
@@ -271,7 +270,7 @@ typename cl_build_status build_opencl_program(typename cl_program program, typen
     // The spec technically does not say whether the build log is zero-terminated, so let's be careful.
     build_log[ret_val_size] = '\0';
 
-    fprintf(stderr, "Build log:\n%s", build_log);
+    fprintf(stderr, "Build log:\n%s\n", build_log);
 
     free(build_log);
   }

--- a/src/Futhark/CodeGen/Backends/SequentialC.hs
+++ b/src/Futhark/CodeGen/Backends/SequentialC.hs
@@ -8,13 +8,14 @@ module Futhark.CodeGen.Backends.SequentialC
 
 import Futhark.Representation.ExplicitMemory
 
-import qualified Futhark.CodeGen.ImpGen as ImpGen
+import qualified Futhark.CodeGen.ImpCode.Sequential as Imp
+import qualified Futhark.CodeGen.ImpGen.Sequential as ImpGen
 import qualified Futhark.CodeGen.Backends.GenericC as GenericC
 
 compileProg :: Prog -> Either String String
 compileProg = fmap (GenericC.compileProg operations () [] [] [] []) .
-              ImpGen.compileProgSimply
-  where operations :: GenericC.Operations () ()
+              ImpGen.compileProg
+  where operations :: GenericC.Operations Imp.Sequential ()
         operations = GenericC.defaultOperations {
           GenericC.opsCompiler = const $ return GenericC.Done
           }

--- a/src/Futhark/CodeGen/Backends/SequentialPython.hs
+++ b/src/Futhark/CodeGen/Backends/SequentialPython.hs
@@ -4,8 +4,8 @@ module Futhark.CodeGen.Backends.SequentialPython
 
    import Futhark.Representation.ExplicitMemory
 
-   import qualified Futhark.CodeGen.ImpGen as ImpGen
+   import qualified Futhark.CodeGen.ImpGen.Sequential as ImpGen
    import qualified Futhark.CodeGen.Backends.GenericPython as GenericPython
 
    compileProg :: Prog -> Either String String
-   compileProg = fmap GenericPython.compileProg . ImpGen.compileProgSimply
+   compileProg = fmap GenericPython.compileProg . ImpGen.compileProg

--- a/src/Futhark/CodeGen/ImpCode/OpenCL.hs
+++ b/src/Futhark/CodeGen/ImpCode/OpenCL.hs
@@ -1,0 +1,60 @@
+-- | Imperative code with an OpenCL component.
+--
+-- Apart from ordinary imperative code, this also carries around an
+-- OpenCL program as a string, as well as a list of kernels defined by
+-- the OpenCL program.
+--
+-- The imperative code has been augmented with a 'LaunchKernel'
+-- operation that allows one to execute an OpenCL kernel.
+module Futhark.CodeGen.ImpCode.OpenCL
+       ( Program (..)
+       , Function
+       , FunctionT (Function)
+       , Code
+       , KernelName
+       , KernelArg (..)
+       , OpenCL (..)
+       , transposeBlockDim
+       , module Futhark.CodeGen.ImpCode
+       )
+       where
+
+import Futhark.CodeGen.ImpCode hiding (Function, Code)
+import qualified Futhark.CodeGen.ImpCode as Imp
+
+import Futhark.Util.Pretty hiding (space)
+
+-- | An program calling OpenCL kernels.
+data Program = Program { openClProgram :: String
+                       , openClKernelNames :: [KernelName]
+                       , hostFunctions :: Functions OpenCL
+                       }
+
+-- | A function calling OpenCL kernels.
+type Function = Imp.Function OpenCL
+
+-- | A piece of code calling OpenCL.
+type Code = Imp.Code OpenCL
+
+-- | The name of a kernel.
+type KernelName = String
+
+-- | An argument to be passed to a kernel.
+data KernelArg = ValueArg Exp BasicType
+                 -- ^ Pass the value of this scalar expression as argument.
+               | MemArg VName
+                 -- ^ Pass this pointer as argument.
+               | SharedMemoryArg (Count Bytes)
+                 -- ^ Create this much local memory per workgroup.
+               deriving (Show)
+
+-- | Host-level OpenCL operation.
+data OpenCL = LaunchKernel KernelName [KernelArg] [Exp] (Maybe [Exp])
+            deriving (Show)
+
+-- | The block size when transposing.
+transposeBlockDim :: Num a => a
+transposeBlockDim = 16
+
+instance Pretty OpenCL where
+  ppr = text . show

--- a/src/Futhark/CodeGen/ImpCode/Sequential.hs
+++ b/src/Futhark/CodeGen/ImpCode/Sequential.hs
@@ -1,0 +1,30 @@
+-- | Sequential imperative code.
+module Futhark.CodeGen.ImpCode.Sequential
+       ( Program
+       , Function
+       , FunctionT (Function)
+       , Code
+       , Sequential
+       , module Futhark.CodeGen.ImpCode
+       )
+       where
+
+import Futhark.CodeGen.ImpCode hiding (Function, Code)
+import qualified Futhark.CodeGen.ImpCode as Imp
+
+import Futhark.Util.Pretty hiding (space)
+
+-- | An imperative program.
+type Program = Imp.Functions Sequential
+
+-- | An imperative function.
+type Function = Imp.Function Sequential
+
+-- | A piece of imperative code.
+type Code = Imp.Code Sequential
+
+-- | Phantom type for identifying sequential imperative code.
+data Sequential
+
+instance Pretty Sequential where
+  ppr _ = empty

--- a/src/Futhark/CodeGen/ImpGen.hs
+++ b/src/Futhark/CodeGen/ImpGen.hs
@@ -2,7 +2,6 @@
 module Futhark.CodeGen.ImpGen
   ( -- * Entry Points
     compileProg
-  , compileProgSimply
 
     -- * Pluggable Compiler
   , ExpCompiler
@@ -36,7 +35,6 @@ module Futhark.CodeGen.ImpGen
   , compileSubExp
   , compileResultSubExp
   , subExpToDimSize
-  , sizeToExp
   , sizeToScalExp
   , declaringLParams
   , declaringVarEntry
@@ -52,7 +50,7 @@ module Futhark.CodeGen.ImpGen
   , varIndex
   , basicScalarSize
   , scalExpToImpExp
-  , dimSizeToExp
+  , Imp.dimSizeToExp
   , destinationFromParam
   , destinationFromParams
   , copyElementWise
@@ -249,14 +247,11 @@ emit :: Imp.Code op -> ImpM op ()
 emit = tell
 
 compileProg :: Operations op -> Imp.Space
-            -> Prog -> Either String (Imp.Program op)
+            -> Prog -> Either String (Imp.Functions op)
 compileProg ops ds prog =
-  Imp.Program <$> snd <$> mapAccumLM (compileFunDec ops ds) src (progFunctions prog)
+  Imp.Functions <$> snd <$>
+  mapAccumLM (compileFunDec ops ds) src (progFunctions prog)
   where src = newNameSourceForProg prog
-
--- | 'compileProg' with 'defaultOperations' and 'DefaultSpace'.
-compileProgSimply :: Prog -> Either String (Imp.Program ())
-compileProgSimply = compileProg defaultOperations Imp.DefaultSpace
 
 compileInParam :: FParam -> ImpM op (Either Imp.Param ArrayDecl)
 compileInParam fparam = case t of
@@ -543,7 +538,7 @@ defCompilePrimOp
           let srcloc = entryArrayLocation yentry
               rows = case entryArrayShape yentry of
                       []  -> error $ "defCompilePrimOp Concat: empty array shape for " ++ pretty y
-                      r:_ -> innerExp $ dimSizeToExp r
+                      r:_ -> innerExp $ Imp.dimSizeToExp r
           copy et destloc srcloc (arrayOuterSize yentry)
           emit $ Imp.SetScalar offs_glb $ Imp.ScalarVar offs_glb + rows
 
@@ -835,16 +830,6 @@ subExpToDimSize (Constant (IntVal i)) =
 subExpToDimSize (Constant {}) =
   throwError "Size subexp is not a non-integer constant."
 
-dimSizeToExp :: Imp.DimSize -> Count Elements
-dimSizeToExp = elements . sizeToExp
-
-memSizeToExp :: Imp.MemSize -> Count Bytes
-memSizeToExp = bytes . sizeToExp
-
-sizeToExp :: Imp.Size -> Imp.Exp
-sizeToExp (Imp.VarSize v)   = Imp.ScalarVar v
-sizeToExp (Imp.ConstSize x) = Imp.Constant $ IntVal $ fromIntegral x
-
 sizeToScalExp :: Imp.Size -> SE.ScalExp
 sizeToScalExp (Imp.VarSize v)   = SE.Id v Int
 sizeToScalExp (Imp.ConstSize x) = SE.Val $ IntVal x
@@ -865,7 +850,7 @@ compileResultSubExp (MemoryDestination mem memsizetarget) (Var v) = do
       return ()
     Just memsizetarget' ->
       emit $ Imp.SetScalar memsizetarget' $
-      innerExp $ dimSizeToExp memsize
+      innerExp $ Imp.dimSizeToExp memsize
 
 compileResultSubExp (MemoryDestination {}) (Constant {}) =
   throwError "Memory destination result subexpression cannot be a constant."
@@ -889,12 +874,12 @@ compileResultSubExp (ArrayDestination memdest shape) (Var v) = do
       emit $ Imp.SetMem mem srcmem
       case memsize of Nothing -> return ()
                       Just memsize' -> emit $ Imp.SetScalar memsize' $
-                                       innerExp $ memSizeToExp srcmemsize
+                                       innerExp $ Imp.memSizeToExp srcmemsize
   zipWithM_ maybeSetShape shape $ entryArrayShape arr
   where maybeSetShape Nothing _ =
           return ()
         maybeSetShape (Just dim) size =
-          emit $ Imp.SetScalar dim $ innerExp $ dimSizeToExp size
+          emit $ Imp.SetScalar dim $ innerExp $ Imp.dimSizeToExp size
 
 compileResultSubExp (ArrayDestination {}) (Constant {}) =
   throwError "Array destination result subexpression cannot be a constant."
@@ -1033,7 +1018,7 @@ subExpNotArray se = subExpType se >>= \case
 
 arrayOuterSize :: ArrayEntry -> Count Elements
 arrayOuterSize =
-  product . map dimSizeToExp . take 1 . entryArrayShape
+  product . map Imp.dimSizeToExp . take 1 . entryArrayShape
 
 -- More complicated read/write operations that use index functions.
 
@@ -1060,7 +1045,7 @@ defaultCopy bt dest src n
   | otherwise =
       copyElementWise bt dest src n
   where bt_size = basicScalarSize bt
-        row_size = product $ map dimSizeToExp $ drop 1 srcshape
+        row_size = product $ map Imp.dimSizeToExp $ drop 1 srcshape
         MemLocation destmem _ destIxFun = dest
         MemLocation srcmem srcshape srcIxFun = src
 
@@ -1071,7 +1056,7 @@ copyElementWise bt (MemLocation destmem destshape destIxFun) (MemLocation srcmem
       let ivars = map varIndex is
           destidx = simplifyScalExp $ IxFun.index destIxFun ivars bt_size
           srcidx = simplifyScalExp $ IxFun.index srcIxFun ivars bt_size
-          bounds = map innerExp $ n : drop 1 (map dimSizeToExp destshape)
+          bounds = map innerExp $ n : drop 1 (map Imp.dimSizeToExp destshape)
       srcspace <- entryMemSpace <$> lookupMemory srcmem
       destspace <- entryMemSpace <$> lookupMemory destmem
       emit $ foldl (.) id (zipWith Imp.For is bounds) $
@@ -1099,7 +1084,7 @@ copyElem bt
   destlocation' <- indexArray destlocation destis
   srclocation'  <- indexArray srclocation  srcis
   collect $ copy bt destlocation' srclocation' $
-    product $ map dimSizeToExp $ drop (length srcis) srcshape
+    product $ map Imp.dimSizeToExp $ drop (length srcis) srcshape
 
 scalExpToImpExp :: ScalExp -> Maybe Imp.Exp
 scalExpToImpExp (SE.Val x) =

--- a/src/Futhark/CodeGen/ImpGen/Kernels.hs
+++ b/src/Futhark/CodeGen/ImpGen/Kernels.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE TypeFamilies, LambdaCase #-}
-module Futhark.CodeGen.KernelImpGen
+module Futhark.CodeGen.ImpGen.Kernels
   ( compileProg
   )
   where
@@ -17,8 +17,8 @@ import Prelude
 
 import Futhark.MonadFreshNames
 import Futhark.Representation.ExplicitMemory
-import qualified Futhark.CodeGen.KernelImp as Imp
-import Futhark.CodeGen.KernelImp (bytes)
+import qualified Futhark.CodeGen.ImpCode.Kernels as Imp
+import Futhark.CodeGen.ImpCode.Kernels (bytes)
 import qualified Futhark.CodeGen.ImpGen as ImpGen
 import Futhark.Analysis.ScalExp as SE
 import qualified Futhark.Representation.ExplicitMemory.IndexFunction.Unsafe as IxFun
@@ -322,7 +322,7 @@ callKernelCopy bt
 
   -- Note that the shape of the destination and the source are
   -- necessarily the same.
-  let shape = map ImpGen.sizeToExp destshape
+  let shape = map Imp.sizeToExp destshape
       shape_se = map ImpGen.sizeToScalExp destshape
       dest_is = unflattenIndex shape_se $ ImpGen.varIndex global_thread_index
       src_is = dest_is
@@ -486,7 +486,7 @@ isMapTranspose bt
           return (dest_offset', src_offset',
                   num_arrays, size_x, size_y)
         getSizes =
-          case map ImpGen.sizeToExp destshape of
+          case map Imp.sizeToExp destshape of
             [num_arrays, size_x, size_y] -> Just (num_arrays, size_x, size_y)
             [size_x, size_y]             -> Just (1, size_x, size_y)
             _                            -> Nothing

--- a/src/Futhark/CodeGen/ImpGen/Kernels/ToOpenCL.hs
+++ b/src/Futhark/CodeGen/ImpGen/Kernels/ToOpenCL.hs
@@ -1,0 +1,295 @@
+{-# LANGUAGE QuasiQuotes #-}
+-- | This module defines a translation from imperative code with
+-- kernels to imperative code with OpenCL calls.
+module Futhark.CodeGen.ImpGen.Kernels.ToOpenCL
+  ( kernelsToOpenCL
+  )
+  where
+
+import Control.Applicative
+import Control.Monad.State
+import Data.List
+import Data.Monoid
+import qualified Data.HashSet as HS
+
+import qualified Language.C.Syntax as C
+import qualified Language.C.Quote.OpenCL as C
+
+import qualified Futhark.CodeGen.OpenCL.Kernels as Kernels
+import qualified Futhark.CodeGen.Backends.GenericC as GenericC
+import Futhark.CodeGen.Backends.SimpleRepresentation
+import Futhark.CodeGen.ImpCode.Kernels hiding (Program)
+import qualified Futhark.CodeGen.ImpCode.Kernels as ImpKernels
+import Futhark.CodeGen.ImpCode.OpenCL hiding (Program)
+import qualified Futhark.CodeGen.ImpCode.OpenCL as ImpOpenCL
+import Futhark.MonadFreshNames
+import Futhark.Util.Pretty (pretty)
+
+-- | Translate a kernels-program to an OpenCL-program.
+kernelsToOpenCL :: ImpKernels.Program
+                -> Either String ImpOpenCL.Program
+kernelsToOpenCL prog = do
+  (kernels, requirements) <- compileKernels $ getKernels prog
+  let kernel_names = map fst kernels
+      opencl_code = pretty $ openClCode kernels requirements
+  return $ ImpOpenCL.Program
+    opencl_code
+    kernel_names $
+    fmap callKernel $ prog
+
+pointerQuals ::  Monad m => String -> m [C.TypeQual]
+pointerQuals "global"     = return [C.ctyquals|__global|]
+pointerQuals "local"      = return [C.ctyquals|__local volatile|]
+pointerQuals "private"    = return [C.ctyquals|__private|]
+pointerQuals "constant"   = return [C.ctyquals|__constant|]
+pointerQuals "write_only" = return [C.ctyquals|__write_only|]
+pointerQuals "read_only"  = return [C.ctyquals|__read_only|]
+pointerQuals "kernel"     = return [C.ctyquals|__kernel|]
+pointerQuals s            = fail $ "'" ++ s ++ "' is not an OpenCL kernel address space."
+
+type UsedFunctions = [(String,C.Func)] -- The ordering is important!
+
+data OpenClRequirements =
+  OpenClRequirements { _kernelUsedFunctions :: UsedFunctions
+                     , _kernelPragmas :: [String]
+                     }
+
+instance Monoid OpenClRequirements where
+  mempty =
+    OpenClRequirements [] []
+
+  OpenClRequirements used1 pragmas1 `mappend` OpenClRequirements used2 pragmas2 =
+    OpenClRequirements (nubBy cmpFst $ used1 <> used2) (nub $ pragmas1 ++ pragmas2)
+    where cmpFst (x, _) (y, _) = x == y
+
+inKernelOperations :: GenericC.Operations InKernel UsedFunctions
+inKernelOperations = GenericC.Operations
+                     { GenericC.opsCompiler = kernelOps
+                     , GenericC.opsMemoryType = kernelMemoryType
+                     , GenericC.opsWriteScalar = GenericC.writeScalarPointerWithQuals pointerQuals
+                     , GenericC.opsReadScalar = GenericC.readScalarPointerWithQuals pointerQuals
+                     , GenericC.opsAllocate = cannotAllocate
+                     , GenericC.opsCopy = copyInKernel
+                     }
+  where kernelOps :: GenericC.OpCompiler InKernel UsedFunctions
+        kernelOps (GetGroupId v i) = do
+          GenericC.stm [C.cstm|$id:v = get_group_id($int:i);|]
+          return GenericC.Done
+        kernelOps (GetLocalId v i) = do
+          GenericC.stm [C.cstm|$id:v = get_local_id($int:i);|]
+          return GenericC.Done
+        kernelOps (GetLocalSize v i) = do
+          GenericC.stm [C.cstm|$id:v = get_local_size($int:i);|]
+          return GenericC.Done
+        kernelOps (GetGlobalId v i) = do
+          GenericC.stm [C.cstm|$id:v = get_global_id($int:i);|]
+          return GenericC.Done
+        kernelOps (GetGlobalSize v i) = do
+          GenericC.stm [C.cstm|$id:v = get_global_size($int:i);|]
+          return GenericC.Done
+
+        cannotAllocate :: GenericC.Allocate InKernel UsedFunctions
+        cannotAllocate _ =
+          fail "Cannot allocate memory in kernel"
+
+        copyInKernel :: GenericC.Copy InKernel UsedFunctions
+        copyInKernel _ _ _ _ _ _ _ =
+          fail $ "Cannot bulk copy in kernel."
+
+        kernelMemoryType space = do
+          quals <- pointerQuals space
+          return [C.cty|$tyquals:quals $ty:defaultMemBlockType|]
+
+compileKernels :: [CallKernel] -> Either String ([(String, C.Func)], OpenClRequirements)
+compileKernels kernels = do
+  (funcs, reqs) <- unzip <$> mapM compileKernel kernels
+  return (concat funcs, mconcat reqs)
+
+compileKernel :: CallKernel -> Either String ([(String, C.Func)], OpenClRequirements)
+compileKernel (Kernel kernel) =
+  let (funbody, s) =
+        GenericC.runCompilerM (Functions []) inKernelOperations blankNameSource mempty $
+        GenericC.collect $ GenericC.compileCode $ kernelBody kernel
+
+      used_funs = GenericC.compUserState s
+
+      params = map useAsParam $ kernelUses kernel
+
+      kernel_funs = functionsCalled $ kernelBody kernel
+
+  in Right ([(mapKernelName kernel,
+             [C.cfun|__kernel void $id:(mapKernelName kernel) ($params:params) {
+                 const uint $id:(kernelThreadNum kernel) = get_global_id(0);
+                 $items:funbody
+             }|])],
+            OpenClRequirements (used_funs ++ requiredFunctions kernel_funs) [])
+
+compileKernel (Reduce kernel) =
+  let ((kernel_prologue, fold_body, red_body,
+        write_fold_result, write_final_result), s) =
+        GenericC.runCompilerM (Functions []) inKernelOperations blankNameSource mempty $ do
+          kernel_prologue_ <-
+            GenericC.collect $ GenericC.compileCode $ reductionPrologue kernel
+          fold_body_ <-
+            GenericC.collect $ GenericC.compileCode $ reductionFoldOperation kernel
+          red_body_ <-
+            GenericC.collect $ GenericC.compileCode $ reductionReduceOperation kernel
+          write_fold_result_ <-
+            GenericC.collect $ GenericC.compileCode $ reductionWriteFoldResult kernel
+
+          write_final_result_ <-
+            GenericC.collect $ GenericC.compileCode $ reductionWriteFinalResult kernel
+
+          return (kernel_prologue_, fold_body_, red_body_,
+                  write_fold_result_, write_final_result_)
+
+      used_funs = GenericC.compUserState s
+
+      use_params = map useAsParam $ reductionUses kernel
+
+      kernel_funs = functionsCalled (reductionReduceOperation kernel) <>
+                    functionsCalled (reductionFoldOperation kernel)
+
+      local_memory_params =
+        flip evalState (blankNameSource :: VNameSource) $
+        mapM prepareLocalMemory $ reductionThreadLocalMemory kernel
+
+      prologue = kernel_prologue
+
+      opencl_kernel =
+        Kernels.reduce Kernels.Reduction
+         { Kernels.reductionKernelName =
+            reduceKernelName kernel
+         , Kernels.reductionOffsetName =
+             textual $ reductionOffsetName kernel
+         , Kernels.reductionInputArrayIndexName =
+             textual $ reductionKernelName kernel
+
+         , Kernels.reductionPrologue = prologue
+         , Kernels.reductionFoldOperation = fold_body
+         , Kernels.reductionWriteFoldResult = write_fold_result
+         , Kernels.reductionReduceOperation = red_body
+         , Kernels.reductionWriteFinalResult = write_final_result
+
+         , Kernels.reductionKernelArgs =
+             local_memory_params ++ use_params
+         }
+
+  in Right ([(reduceKernelName kernel, opencl_kernel)],
+            OpenClRequirements (used_funs ++ requiredFunctions kernel_funs) [])
+  where prepareLocalMemory (mem, _) =
+          return ([C.cparam|__local volatile unsigned char* restrict $id:mem|])
+
+compileKernel kernel@(MapTranspose bt _ _ _ _ _ _ _) =
+  Right ([(kernelName kernel, Kernels.mapTranspose (kernelName kernel) ty)],
+         mempty)
+  where ty = GenericC.scalarTypeToCType bt
+
+useAsParam :: KernelUse -> C.Param
+useAsParam (ScalarUse name bt) =
+  let ctp = GenericC.scalarTypeToCType bt
+  in [C.cparam|$ty:ctp $id:name|]
+useAsParam (MemoryUse name _) =
+  [C.cparam|__global unsigned char *$id:name|]
+
+requiredFunctions :: HS.HashSet Name -> [(String, C.Func)]
+requiredFunctions kernel_funs =
+  let used_in_kernel = (`HS.member` kernel_funs) . nameFromString . fst
+      funs32_used = filter used_in_kernel funs32
+      funs64_used = filter used_in_kernel funs64
+
+      funs32 = [("toFloat32", c_toFloat32),
+                ("trunc32", c_trunc32),
+                ("log32", c_log32),
+                ("sqrt32", c_sqrt32),
+                ("exp32", c_exp32)]
+
+      funs64 = [("toFloat64", c_toFloat64),
+                ("trunc64", c_trunc64),
+                ("log64", c_log64),
+                ("sqrt64", c_sqrt64),
+                ("exp64", c_exp64)]
+  in funs32_used ++ funs64_used
+
+openClProgramHeader :: OpenClRequirements -> [C.Definition]
+openClProgramHeader (OpenClRequirements used_funs pragmas) =
+  [ [C.cedecl|$esc:pragma|] | pragma <- pragmas ] ++
+  [ [C.cedecl|$func:used_fun|] | (_, used_fun) <- used_funs ]
+
+openClCode :: [(String, C.Func)] -> OpenClRequirements -> [C.Definition]
+openClCode kernels requirements =
+  [C.cunit|
+// Program header and utility functions
+   $edecls:header
+
+// Kernel definitions
+   $edecls:funcs
+          |]
+  where header =
+          openClProgramHeader requirements
+        funcs =
+          [[C.cedecl|$func:kernel_func|] |
+           (_, kernel_func) <- kernels ]
+
+
+mapKernelName :: MapKernel -> String
+mapKernelName = ("map_kernel_"++) . show . baseTag . kernelThreadNum
+
+reduceKernelName :: ReduceKernel -> String
+reduceKernelName = ("red_kernel_"++) . show . baseTag . reductionKernelName
+
+kernelName :: CallKernel -> String
+kernelName (Kernel k) =
+  mapKernelName k
+kernelName (Reduce k) =
+  reduceKernelName k
+kernelName (MapTranspose bt _ _ _ _ _ _ _) =
+  "fut_kernel_map_transpose_" ++ pretty bt
+
+callKernel :: CallKernel -> OpenCL
+callKernel kernel =
+  LaunchKernel
+  (kernelName kernel) (kernelArgs kernel) kernel_size workgroup_size
+  where (kernel_size, workgroup_size) = kernelAndWorkgroupSize kernel
+
+kernelArgs :: CallKernel -> [KernelArg]
+kernelArgs (Kernel kernel) =
+  map useToArg $ kernelUses kernel
+kernelArgs (Reduce kernel) =
+  map (SharedMemoryArg . memSizeToExp . snd)
+      (reductionThreadLocalMemory kernel) ++
+  map useToArg (reductionUses kernel)
+kernelArgs (MapTranspose bt destmem destoffset srcmem srcoffset _ x_elems y_elems) =
+  [ MemArg destmem
+  , ValueArg destoffset Int
+  , MemArg srcmem
+  , ValueArg srcoffset Int
+  , ValueArg x_elems Int
+  , ValueArg y_elems Int
+  , SharedMemoryArg shared_memory
+  ]
+  where shared_memory =
+          bytes $ (transposeBlockDim + 1) * transposeBlockDim * SizeOf bt
+
+kernelAndWorkgroupSize :: CallKernel -> ([Exp], Maybe [Exp])
+kernelAndWorkgroupSize (Kernel kernel) =
+  ([sizeToExp $ kernelSize kernel],
+   Nothing)
+kernelAndWorkgroupSize (Reduce kernel) =
+  ([sizeToExp (reductionNumGroups kernel) *
+    sizeToExp (reductionGroupSize kernel)],
+   Just [sizeToExp $ reductionGroupSize kernel])
+kernelAndWorkgroupSize (MapTranspose _ _ _ _ _ num_arrays x_elems y_elems) =
+  ([roundedToBlockDim x_elems,
+    roundedToBlockDim y_elems,
+    roundedToBlockDim num_arrays],
+   Just [transposeBlockDim, transposeBlockDim, 1])
+  where roundedToBlockDim e =
+          e + ((transposeBlockDim -
+                (e `impRem` transposeBlockDim)) `impRem`
+               transposeBlockDim)
+        impRem = BinOp Rem
+
+useToArg :: KernelUse -> KernelArg
+useToArg (MemoryUse mem _) = MemArg mem
+useToArg (ScalarUse v bt)  = ValueArg (ScalarVar v) bt

--- a/src/Futhark/CodeGen/ImpGen/OpenCL.hs
+++ b/src/Futhark/CodeGen/ImpGen/OpenCL.hs
@@ -1,0 +1,15 @@
+module Futhark.CodeGen.ImpGen.OpenCL
+  ( compileProg
+  ) where
+
+import Control.Monad
+
+import Prelude
+
+import Futhark.Representation.ExplicitMemory (Prog)
+import qualified Futhark.CodeGen.ImpCode.OpenCL as OpenCL
+import qualified Futhark.CodeGen.ImpGen.Kernels as ImpGenKernels
+import Futhark.CodeGen.ImpGen.Kernels.ToOpenCL
+
+compileProg :: Prog -> Either String OpenCL.Program
+compileProg = kernelsToOpenCL <=< ImpGenKernels.compileProg

--- a/src/Futhark/CodeGen/ImpGen/Sequential.hs
+++ b/src/Futhark/CodeGen/ImpGen/Sequential.hs
@@ -1,0 +1,12 @@
+module Futhark.CodeGen.ImpGen.Sequential
+  ( compileProg
+  )
+  where
+
+import Futhark.Representation.ExplicitMemory
+
+import qualified Futhark.CodeGen.ImpCode.Sequential as Imp
+import qualified Futhark.CodeGen.ImpGen as ImpGen
+
+compileProg :: Prog -> Either String Imp.Program
+compileProg = ImpGen.compileProg ImpGen.defaultOperations Imp.DefaultSpace

--- a/src/Futhark/CodeGen/SetDefaultSpace.hs
+++ b/src/Futhark/CodeGen/SetDefaultSpace.hs
@@ -6,10 +6,10 @@ module Futhark.CodeGen.SetDefaultSpace
 
 import Futhark.CodeGen.ImpCode
 
-setDefaultSpace :: Space -> Program op -> Program op
-setDefaultSpace space (Program fundecs) =
-  Program [ (fname, setFunctionSpace space func)
-          | (fname, func) <- fundecs ]
+setDefaultSpace :: Space -> Functions op -> Functions op
+setDefaultSpace space (Functions fundecs) =
+  Functions [ (fname, setFunctionSpace space func)
+            | (fname, func) <- fundecs ]
 
 setFunctionSpace :: Space -> Function op -> Function op
 setFunctionSpace space (Function outputs inputs body results args) =
@@ -19,7 +19,6 @@ setFunctionSpace space (Function outputs inputs body results args) =
   (setBodySpace space body)
   results
   args
-
 
 setParamSpace :: Space -> Param -> Param
 setParamSpace space (MemParam name size DefaultSpace) =


### PR DESCRIPTION
The biggest difference is that I have created specialised modules for each invariant of the imperative code, including a new one that contains OpenCL (`Futhark.CodeGen.ImpCode.OpenCL`).  This is the one you will use when you get to OpenCL code generation (and also the main motivation for this merge).

I modified your Python code generator to import `Futhark.CodeGen.ImpCode.Sequential`, because right now it's not really a generic code generator.  Once you get further, we will move back to importing the generic `Futhark.CodeGen.ImpCode`, but for now, let's pretend imperative code is our only care in the world.