### PR TITLE
Faster scans

### DIFF
--- a/data/tests/distribution/distribution3.fut
+++ b/data/tests/distribution/distribution3.fut
@@ -9,7 +9,7 @@
 --
 -- ==
 --
--- structure distributed { Map 0 MapKernel 8 ScanKernel 4 }
+-- structure distributed { Map 0 MapKernel 4 ScanKernel 4 }
 
 fun [[[int]]] main([[[int,m],n]] a) =
   map(fn [[int,n],m] ([[int]] a_row) =>

--- a/data/tests/distribution/distribution5.fut
+++ b/data/tests/distribution/distribution5.fut
@@ -15,7 +15,7 @@
 -- ==
 --
 -- structure distributed {
---   MapKernel 8
+--   MapKernel 6
 --   ScanKernel 2
 --   Map 0
 --   Concat 1

--- a/data/tests/streamRed_interchange.fut
+++ b/data/tests/streamRed_interchange.fut
@@ -111,7 +111,7 @@
 -- -0.000443f32, 0.000283f32, -0.000084f32, 0.000129f32, 0.000419f32,
 -- -0.000178f32, -0.001124f32, -0.001211f32, 0.000297f32, 0.000291f32,
 -- 0.001163f32, 0.001455f32]]}
--- structure distributed { ChunkedMapKernel 1 MapKernel 5 ScanKernel 2 }
+-- structure distributed { ChunkedMapKernel 1 MapKernel 3 ScanKernel 2 }
 
 fun [[f32,nfeatures],nclusters] main(int nfeatures, int npoints, int nclusters) =
   let membership = map(%nclusters, iota(npoints)) in

--- a/src/Futhark/CodeGen/ImpGen/Kernels.hs
+++ b/src/Futhark/CodeGen/ImpGen/Kernels.hs
@@ -15,7 +15,7 @@ import qualified Data.HashMap.Lazy as HM
 import qualified Data.HashSet as HS
 import Data.List
 
-import Prelude
+import Prelude hiding (quot)
 
 import Futhark.MonadFreshNames
 import Futhark.Transform.Rename
@@ -27,7 +27,7 @@ import qualified Futhark.Analysis.ScalExp as SE
 import qualified Futhark.Representation.ExplicitMemory.IndexFunction as IxFun
 import Futhark.CodeGen.SetDefaultSpace
 import Futhark.Tools (partitionChunkedKernelLambdaParameters)
-import Futhark.Util.IntegralExp (quotRoundingUp)
+import Futhark.Util.IntegralExp (quotRoundingUp, quot)
 
 type CallKernelGen = ImpGen.ImpM Imp.HostOp
 type InKernelGen = ImpGen.ImpM Imp.KernelOp
@@ -405,14 +405,16 @@ kernelCompiler
 
 kernelCompiler
   (ImpGen.Destination dest)
-  (ScanKernel _ _ kernel_size order lam foldlam nes arrs) = do
+  (ScanKernel _ _ kernel_size lam foldlam nes arrs) = do
     let (arrs_dest, partials_dest) = splitAt (length nes) dest
     (local_id, group_id, wave_size, global_id) <- kernelSizeNames
     thread_chunk_size <- newVName "thread_chunk_size"
+    chunks_per_group <- newVName "chunks_per_group"
+    chunk_index <- newVName "chunk_index"
 
     renamed_lam <- renameLambda lam
 
-    (num_groups, local_size, elements_per_thread,
+    (num_groups, local_size, _elements_per_thread,
      num_elements, _offset_multiple, num_threads) <-
       compileKernelSize kernel_size
 
@@ -424,17 +426,17 @@ kernelCompiler
           partitionChunkedKernelLambdaParameters $ lambdaParams lam
         (x_params, y_params) =
           splitAt (length nes) actual_params
+        is_last_thread_in_group = Imp.CmpOp (CmpEq int32)
+                                  (Imp.ScalarVar local_id)
+                                  (Imp.sizeToExp local_size - 1)
+        is_first_thread_in_group = Imp.CmpOp (CmpEq int32)
+                                   (Imp.ScalarVar local_id)
+                                   0
+        num_waves = Imp.sizeToExp local_size `quot`
+                    Imp.ScalarVar wave_size
 
     (acc_mem_params, acc_local_mem) <-
       unzip <$> mapM (createAccMem local_size) fold_x_params
-
-    let twoDimInput (ImpGen.ArrayEntry (ImpGen.MemLocation mem shape ixfun) bt) =
-          let shape' = [num_threads, elements_per_thread] ++ drop 1 shape
-              ixfun' = IxFun.reshape ixfun $
-                       [DimNew $ SE.intSubExpToScalExp $ kernelNumThreads kernel_size,
-                        DimNew $ SE.intSubExpToScalExp $ kernelElementsPerThread kernel_size] ++
-                       map (DimNew . SE.intSubExpToScalExp . ImpGen.dimSizeToSubExp) (drop 1 shape)
-          in ImpGen.ArrayEntry (ImpGen.MemLocation mem shape' ixfun') bt
 
     (call_with_body, body) <-
       makeAllMemoryGlobal $ ImpGen.subImpM inKernelOperations $
@@ -442,138 +444,127 @@ kernelCompiler
       ImpGen.declaringPrimVar group_id int32 $
       ImpGen.declaringPrimVar wave_size int32 $
       ImpGen.declaringPrimVar thread_chunk_size int32 $
+      ImpGen.declaringPrimVar chunks_per_group int32 $
       ImpGen.declaringPrimVar global_id int32 $
       ImpGen.withParams acc_mem_params $
       ImpGen.declaringLParams (lambdaParams lam) $
       ImpGen.declaringLParams (lambdaParams renamed_lam) $
-      ImpGen.declaringLParams (lambdaParams foldlam) $
-      ImpGen.modifyingArrays arrs twoDimInput $ do
+      ImpGen.declaringLParams (lambdaParams foldlam) $ do
 
         ImpGen.emit $
           Imp.Op (Imp.GetLocalId local_id 0) <>
           Imp.Op (Imp.GetGroupId group_id 0) <>
           Imp.Op (Imp.GetGlobalId global_id 0) <>
-          Imp.Op (Imp.GetLockstepWidth wave_size)
-
-        -- 'fold_lam_i' is the offset of the element that the
-        -- current thread is responsible for.  Since a single
-        -- workgroup processes more elements than it has threads, this
-        -- will change over time.
-        ImpGen.emit $
-          Imp.SetScalar fold_lam_i $
-          Imp.ScalarVar global_id *
-          Imp.innerExp (Imp.dimSizeToExp elements_per_thread)
+          Imp.Op (Imp.GetLockstepWidth wave_size) <>
+          Imp.SetScalar chunks_per_group
+            (Imp.sizeToExp num_elements `quotRoundingUp`
+             Imp.sizeToExp num_threads)
 
         fold_x_dest <- ImpGen.destinationFromParams fold_x_params
 
         y_dest <- ImpGen.destinationFromParams y_params
 
-        -- The number of elements processed by the thread so far.
-        elements_scanned <- newVName "elements_scanned"
-
-        let readScanElement param inp_arr =
-              ImpGen.copyDWIM (paramName param) []
-              (Var inp_arr) [ImpGen.varIndex global_id,
-                             ImpGen.varIndex elements_scanned]
-
-        computeThreadChunkSize
-          Noncommutative
-          (Imp.ScalarVar global_id)
-          (Imp.innerExp $ Imp.dimSizeToExp num_threads)
-          (ImpGen.dimSizeToExp elements_per_thread)
-          (ImpGen.dimSizeToExp num_elements)
-          thread_chunk_size
-
-        zipWithM_ ImpGen.compileSubExpTo
+        set_fold_x_to_ne <- ImpGen.collect $
+          zipWithM_ ImpGen.compileSubExpTo
           (ImpGen.valueDestinations fold_x_dest) nes
 
-        read_params <-
-          ImpGen.collect $ zipWithM_ readScanElement fold_y_params arrs
+        ImpGen.emit set_fold_x_to_ne
 
-        let (indices, explode_n, explode_m) = case order of
-              ScanTransposed -> ([elements_scanned, global_id],
-                                 kernelElementsPerThread kernel_size,
-                                 kernelNumThreads kernel_size)
-              ScanFlat       ->  ([global_id, elements_scanned],
-                                  kernelNumThreads kernel_size,
-                                  kernelElementsPerThread kernel_size)
+        scan_chunk <- ImpGen.collect $ do
+          -- Every thread reads an element from the input array and
+          -- applies the fold function, writing the result to
+          -- x_params.  If the element is beyond the end of the
+          -- array, we write the neutral element instead.
 
-            writeScanElement (ImpGen.ArrayDestination
-                              (ImpGen.CopyIntoMemory (ImpGen.MemLocation mem dims ixfun))
-                              setdims) =
-              writeFinalResult indices $
-              ImpGen.ArrayDestination
-              (ImpGen.CopyIntoMemory (ImpGen.MemLocation mem dims ixfun'))
-              setdims
-              where ixfun' = explodeOuterDimension
-                             (Shape $ map sizeToSubExp dims)
-                             explode_n explode_m ixfun
-            writeScanElement _ =
-              const $ fail "writeScanElement: invalid destination"
+          -- Compute our element index.
+          ImpGen.emit $ Imp.SetScalar fold_lam_i $
+            (Imp.ScalarVar group_id * Imp.ScalarVar chunks_per_group +
+             Imp.ScalarVar chunk_index) * Imp.sizeToExp local_size +
+            Imp.ScalarVar local_id
 
-            sizeToSubExp (Imp.ConstSize k) = constant k
-            sizeToSubExp (Imp.VarSize v)   = Var v
+          let readFoldElement param inp_arr =
+                ImpGen.copyDWIM (paramName param) []
+                (Var inp_arr) [ImpGen.varIndex fold_lam_i]
 
-        write_arrs <-
-          ImpGen.collect $ zipWithM_ writeScanElement arrs_dest fold_x_params
+          apply_fold_fun <- ImpGen.collect $ do
+            zipWithM_ readFoldElement fold_y_params arrs
+            ImpGen.compileBody fold_x_dest $ lambdaBody foldlam
 
-        op_to_x <- ImpGen.collect $ ImpGen.compileBody fold_x_dest $ lambdaBody foldlam
+          let is_in_bounds = Imp.CmpOp (CmpUlt Int32)
+                             (Imp.ScalarVar fold_lam_i) (Imp.sizeToExp num_elements)
+          ImpGen.emit $
+            Imp.Comment "Apply the fold function if we are still within bounds" $
+            Imp.If is_in_bounds apply_fold_fun mempty
+
+          -- Write the fold_x_params to local memory for the parallel step.
+          zipWithM_ (writeParamToLocalMemory $ Imp.ScalarVar local_id)
+            acc_local_mem fold_x_params
+
+          let wave_id = Imp.BinOp (SQuot Int32)
+                        (Imp.ScalarVar local_id)
+                        (Imp.ScalarVar wave_size)
+              in_wave_id = Imp.ScalarVar local_id -
+                           (wave_id * Imp.ScalarVar wave_size)
+              doInWaveScan = inWaveScan (Imp.ScalarVar wave_size) local_id acc_local_mem
+
+          doInWaveScan lam
+          ImpGen.emit $ Imp.Op Imp.Barrier
+
+          pack_wave_results <-
+            ImpGen.collect $
+            zipWithM_ (writeParamToLocalMemory wave_id) acc_local_mem y_params
+
+          let last_in_wave =
+                Imp.CmpOp (CmpEq int32) in_wave_id $ Imp.ScalarVar wave_size - 1
+          ImpGen.emit $
+            Imp.Comment "last thread of wave 'i' writes its result to offset 'i'" $
+            Imp.If last_in_wave pack_wave_results mempty
+
+          ImpGen.emit $ Imp.Op Imp.Barrier
+
+          let is_first_wave = Imp.CmpOp (CmpEq int32) wave_id 0
+          scan_first_wave <- ImpGen.collect $ doInWaveScan renamed_lam
+          ImpGen.emit $
+            Imp.Comment "scan the first wave, after which offset 'i' contains carry-in for warp 'i+1'" $
+            Imp.If is_first_wave scan_first_wave mempty
+
+          ImpGen.emit $ Imp.Op Imp.Barrier
+
+          read_carry_in <-
+            ImpGen.collect $
+            zipWithM_ (readParamFromLocalMemory
+                       (paramName other_index_param) (wave_id - 1))
+            x_params acc_local_mem
+
+          op_to_y <- ImpGen.collect $ ImpGen.compileBody y_dest $ lambdaBody lam
+          ImpGen.emit $
+            Imp.Comment "carry-in for every wave except the first" $
+            Imp.If is_first_wave mempty $
+            Imp.Comment "read operands" read_carry_in <>
+            Imp.Comment "perform operation" op_to_y
+
+          write_final_elem <- ImpGen.collect $
+            zipWithM_ (writeFinalResult [fold_lam_i]) arrs_dest y_params
+          ImpGen.emit $
+            Imp.Comment "Write element result if we are still within bounds" $
+            Imp.If is_in_bounds write_final_elem mempty
+
+          read_global_carry_in <-
+            ImpGen.collect $
+            zipWithM_ (readParamFromLocalMemory fold_lam_i $ num_waves - 1)
+            fold_x_params acc_local_mem
+          ImpGen.emit $
+            Imp.Comment "The first thread in each workgroup reads the carry-in for the next iteration.  The others reset it to the neutral element." $
+            Imp.If is_first_thread_in_group read_global_carry_in set_fold_x_to_ne
+
+
+        ImpGen.emit $ Imp.For chunk_index (Imp.ScalarVar chunks_per_group) scan_chunk
+
+        write_global_carry_out <- ImpGen.collect $
+          zipWithM_ (writeFinalResult [group_id]) partials_dest y_params
         ImpGen.emit $
-          Imp.Comment "sequentially scan a chunk" $
-          Imp.For elements_scanned (Imp.ScalarVar thread_chunk_size) $
-            read_params <>
-            op_to_x <>
-            write_arrs <>
-            Imp.SetScalar fold_lam_i
-            (Imp.BinOp (Add Int32) (Imp.ScalarVar fold_lam_i) 1)
-
-        zipWithM_ (writeParamToLocalMemory $ Imp.ScalarVar local_id)
-          acc_local_mem fold_x_params
-
-        let wave_id = Imp.BinOp (SQuot Int32)
-                      (Imp.ScalarVar local_id)
-                      (Imp.ScalarVar wave_size)
-            in_wave_id = Imp.ScalarVar local_id -
-                         (wave_id * Imp.ScalarVar wave_size)
-            inWaveScan' = inWaveScan (Imp.ScalarVar wave_size) local_id acc_local_mem
-
-        inWaveScan' lam
-        ImpGen.emit $ Imp.Op Imp.Barrier
-
-        pack_wave_results <-
-          ImpGen.collect $
-          zipWithM_ (writeParamToLocalMemory wave_id) acc_local_mem y_params
-
-        let last_in_wave =
-              Imp.CmpOp (CmpEq int32) in_wave_id $ Imp.ScalarVar wave_size - 1
-        ImpGen.emit $
-          Imp.Comment "last thread of wave 'i' writes its result to offset 'i'" $
-          Imp.If last_in_wave pack_wave_results mempty
-
-        ImpGen.emit $ Imp.Op Imp.Barrier
-
-        let is_first_wave = Imp.CmpOp (CmpEq int32) wave_id 0
-        scan_first_wave <- ImpGen.collect $ inWaveScan' renamed_lam
-        ImpGen.emit $
-          Imp.Comment "scan the first wave, after which offset 'i' contains carry-in for warp 'i+1'" $
-          Imp.If is_first_wave scan_first_wave mempty
-
-        ImpGen.emit $ Imp.Op Imp.Barrier
-
-        read_carry_in <-
-          ImpGen.collect $
-          zipWithM_ (readParamFromLocalMemory
-                     (paramName other_index_param) (wave_id - 1))
-          x_params acc_local_mem
-
-        op_to_y <- ImpGen.collect $ ImpGen.compileBody y_dest $ lambdaBody lam
-        ImpGen.emit $
-          Imp.Comment "carry-in for every wave except the first" $
-          Imp.If is_first_wave mempty $
-          Imp.Comment "read operands" read_carry_in <>
-          Imp.Comment "perform operation" op_to_y
-
-        zipWithM_ (writeFinalResult [group_id, local_id]) partials_dest y_params
+          Imp.Comment "The last thread in each workgroup writes its result as the carry-out of the group." $
+          Imp.If is_last_thread_in_group write_global_carry_out mempty
 
         return $ \body -> do
 
@@ -1167,11 +1158,3 @@ ensureAlignment :: AlignmentMap
                 -> (VName, Imp.Size, PrimType)
 ensureAlignment alignments (name, size) =
   (name, size, lookupAlignment name alignments)
-
-explodeOuterDimension :: Shape -> SubExp -> SubExp
-                      -> IxFun.IxFun SE.ScalExp -> IxFun.IxFun SE.ScalExp
-explodeOuterDimension orig_shape n m ixfun =
-  IxFun.reshape ixfun explode_dims
-  where explode_dims =
-          map (fmap SE.intSubExpToScalExp) $
-          reshapeOuter [DimNew n, DimNew m] 1 orig_shape

--- a/src/Futhark/Pass/ExpandAllocations.hs
+++ b/src/Futhark/Pass/ExpandAllocations.hs
@@ -104,7 +104,7 @@ transformExp (Op (Inner (ReduceKernel cs w kernel_size comm red_lam fold_lam arr
         bound_in_red_lam = HS.fromList $ HM.keys $ scopeOf red_lam
         bound_in_fold_lam = HS.fromList $ HM.keys $ scopeOf fold_lam
 
-transformExp (Op (Inner (ScanKernel cs w kernel_size order lam foldlam nes arrs)))
+transformExp (Op (Inner (ScanKernel cs w kernel_size lam foldlam nes arrs)))
   -- Extract allocations from the lambda.
   | Right (lam_body', lam_thread_allocs) <-
       extractKernelAllocations bound_in_lam $ lambdaBody lam,
@@ -121,7 +121,7 @@ transformExp (Op (Inner (ScanKernel cs w kernel_size order lam foldlam nes arrs)
       foldlam_body'' = offsetMemoryInBody fold_alloc_offsets foldlam_body'
       foldlam' = foldlam { lambdaBody = foldlam_body'' }
   return (alloc_bnds <> fold_alloc_bnds,
-          Op $ Inner $ ScanKernel cs w kernel_size order lam' foldlam' nes arrs)
+          Op $ Inner $ ScanKernel cs w kernel_size lam' foldlam' nes arrs)
   where num_threads = kernelNumThreads kernel_size
         (thread_id, _, _) =
           partitionChunkedKernelLambdaParameters $ lambdaParams lam

--- a/src/Futhark/Pass/ExplicitAllocations.hs
+++ b/src/Futhark/Pass/ExplicitAllocations.hs
@@ -577,10 +577,10 @@ allocInExp (Op (ReduceKernel cs w size comm red_lam fold_lam arrs)) = do
   return $ Op $ Inner $ ReduceKernel cs w size comm red_lam' fold_lam' arrs
   where num_accs = length $ lambdaReturnType red_lam
 
-allocInExp (Op (ScanKernel cs w size order lam foldlam nes arrs)) = do
+allocInExp (Op (ScanKernel cs w size lam foldlam nes arrs)) = do
   lam' <- allocInReduceLambda lam (length nes) $ kernelWorkgroupSize size
   foldlam' <- allocInReduceLambda foldlam (length nes) $ kernelWorkgroupSize size
-  return $ Op $ Inner $ ScanKernel cs w size order lam' foldlam' nes arrs
+  return $ Op $ Inner $ ScanKernel cs w size lam' foldlam' nes arrs
 
 allocInExp (Op (WriteKernel cs t i v a)) =
   -- We require Write to be in-place, so there is no need to allocate any

--- a/src/Futhark/Pass/ExtractKernels/BlockedKernel.hs
+++ b/src/Futhark/Pass/ExtractKernels/BlockedKernel.hs
@@ -250,7 +250,6 @@ blockedScan pat cs w lam input = do
       num_groups = kernelWorkgroups first_scan_size
       group_size = kernelWorkgroupSize first_scan_size
       num_threads = kernelNumThreads first_scan_size
-      elems_per_thread = kernelElementsPerThread first_scan_size
       my_index_param = Param my_index (Prim int32)
       other_index_param = Param other_index (Prim int32)
       first_scan_lam = lam { lambdaParams = my_index_param :
@@ -260,104 +259,59 @@ blockedScan pat cs w lam input = do
   first_scan_lam_renamed <- renameLambda first_scan_lam
   sequential_scan_result <-
     letTupExp "sequentially_scanned" $
-      Op $ ScanKernel cs w first_scan_size ScanFlat
+      Op $ ScanKernel cs w first_scan_size
       first_scan_lam first_scan_lam_renamed nes arrs
 
-  let (sequentially_scanned, all_group_sums) =
+  let (sequentially_scanned, group_carry_out) =
         splitAt (length input) sequential_scan_result
 
-  last_in_preceding_groups <- do
-    lasts_map_index <- newVName "lasts_map_index"
-    group_id <- newVName "group_id"
-    lasts_map_body <- runBodyBinder $ do
-      read_lasts <- runBodyBinder $ do
-        last_in_group_index <-
-          letSubExp "last_in_group_index" $
-          PrimOp $ BinOp (Sub Int32) group_size one
-        carry_in_index <-
-          letSubExp "preceding_group" $ PrimOp $ BinOp (Sub Int32) (Var group_id) one
-        let getLastInPrevious sums =
-              return $ PrimOp $ Index [] sums [carry_in_index, last_in_group_index]
-        eBody $ map getLastInPrevious all_group_sums
+  let second_scan_size = KernelSize one num_groups one num_groups one num_groups
+  second_scan_lam <- renameLambda first_scan_lam
+  second_scan_lam_renamed <- renameLambda first_scan_lam
 
-      group_lasts <-
-        letTupExp "group_lasts" =<<
-        eIf (eCmpOp (CmpSlt Int32) (eSubExp zero) (eSubExp $ Var group_id))
-        (pure read_lasts)
-        (eBody $ map eSubExp nes)
-      return $ resultBody $ map Var group_lasts
-    let lasts_map_returns = [ (rt, [0..arrayRank rt])
-                            | rt <- lambdaReturnType lam ]
-    letTupExp "last_in_preceding_groups" $
-      Op $ MapKernel [] num_groups lasts_map_index
-      [(group_id, num_groups)] [] lasts_map_returns lasts_map_body
-
-  group_carry_in <- do
-    let second_scan_size = KernelSize one num_groups one num_groups one num_groups
-    second_scan_lam <- renameLambda first_scan_lam
-    second_scan_lam_renamed <- renameLambda first_scan_lam
-    carry_in_scan_result <-
-      letTupExp "group_carry_in_and_junk" $
-      Op $ ScanKernel cs num_groups second_scan_size ScanFlat
-      second_scan_lam second_scan_lam_renamed
-      nes last_in_preceding_groups
-    forM (snd $ splitAt (length input) carry_in_scan_result) $ \arr ->
-      letExp "group_carry_in" $
-      PrimOp $ Index [] arr [zero]
-
-  chunk_carry_out <- do
-    lam'' <- renameLambda lam
-    chunk_carry_out_index <- newVName "chunk_carry_out_index"
-    group_id <- newVName "group_id"
-    elem_id <- newVName "elem_id"
-    let (acc_params, arr_params) = splitAt (length nes) $ lambdaParams lam''
-        chunk_carry_out_inputs =
-          zipWith (mkKernelInput [Var group_id]) acc_params group_carry_in ++
-          zipWith (mkKernelInput [Var group_id, Var elem_id]) arr_params all_group_sums
-
-    let chunk_carry_out_returns = [ (rt, [0..arrayRank rt+1])
-                                 | rt <- lambdaReturnType lam ]
-    letTupExp "chunk_carry_out" $
-      Op $ MapKernel [] num_threads chunk_carry_out_index
-      [(group_id, num_groups),
-       (elem_id, group_size)]
-      chunk_carry_out_inputs chunk_carry_out_returns $ lambdaBody lam''
-
-  chunk_carry_out_flat <- forM chunk_carry_out $ \arr -> do
-    arr_shape <- arrayShape <$> lookupType arr
-    letExp "chunk_carry_out_flat" $
-      PrimOp $ Reshape [] (reshapeOuter [DimNew num_threads] 2 arr_shape) arr
+  group_carry_out_scanned <-
+    letTupExp "group_carry_out_scanned" $
+    Op $ ScanKernel cs num_groups second_scan_size
+    second_scan_lam second_scan_lam_renamed
+    nes group_carry_out
 
   lam''' <- renameLambda lam
   result_map_index <- newVName "result_map_index"
   j <- newVName "j"
-  let (acc_params, arr_params) = splitAt (length nes) $ lambdaParams lam'''
-      result_inputs = zipWith (mkKernelInput [Var j]) arr_params sequentially_scanned
+  let (acc_params, arr_params) =
+        splitAt (length nes) $ lambdaParams lam'''
+      result_map_input =
+        zipWith (mkKernelInput [Var j]) arr_params sequentially_scanned
 
-  result_map_body <- runBodyBinder $ inScopeOf result_inputs $ do
-    thread_id <-
-      letSubExp "thread_id" $
-      PrimOp $ BinOp (SQuot Int32) (Var j) elems_per_thread
+  chunks_per_group <- letSubExp "chunks_per_group" =<<
+    eDivRoundingUp Int32 (eSubExp w) (eSubExp num_threads)
+  elems_per_group <- letSubExp "elements_per_group" $
+    PrimOp $ BinOp (Mul Int32) chunks_per_group group_size
+
+  result_map_body <- runBodyBinder $ inScopeOf result_map_input $ do
+    group_id <-
+      letSubExp "group_id" $
+      PrimOp $ BinOp (SQuot Int32) (Var j) elems_per_group
     let do_nothing =
           pure $ resultBody $ map (Var . paramName) arr_params
         add_carry_in = runBodyBinder $ do
-          forM_ (zip acc_params chunk_carry_out_flat) $ \(p, arr) -> do
+          forM_ (zip acc_params group_carry_out_scanned) $ \(p, arr) -> do
             carry_in_index <-
               letSubExp "carry_in_index" $
-              PrimOp $ BinOp (Sub Int32) thread_id one
+              PrimOp $ BinOp (Sub Int32) group_id one
             letBindNames'_ [paramName p] $
               PrimOp $ Index [] arr [carry_in_index]
           return $ lambdaBody lam'''
     group_lasts <-
       letTupExp "final_result" =<<
-        eIf (eCmpOp (CmpEq int32) (eSubExp zero) (eSubExp thread_id))
+        eIf (eCmpOp (CmpEq int32) (eSubExp zero) (eSubExp group_id))
         do_nothing
         add_carry_in
     return $ resultBody $ map Var group_lasts
   let result_map_returns = [ (rt, [0..arrayRank rt])
                            | rt <- lambdaReturnType lam ]
   letBind_ pat $ Op $ MapKernel [] w result_map_index
-    [(j, w)] result_inputs result_map_returns result_map_body
+    [(j, w)] result_map_input result_map_returns result_map_body
   where one = constant (1 :: Int32)
         zero = constant (0 :: Int32)
 

--- a/src/Futhark/Representation/Kernels/Kernel.hs
+++ b/src/Futhark/Representation/Kernels/Kernel.hs
@@ -14,7 +14,6 @@ module Futhark.Representation.Kernels.Kernel
        , kernelInputType
        , kernelInputIdent
        , KernelSize(..)
-       , ScanKernelOrder(..)
        , chunkedKernelNonconcatOutputs
 
        , typeCheckKernel
@@ -68,7 +67,6 @@ data Kernel lore =
     [VName]
   | ScanKernel Certificates SubExp
     KernelSize
-    ScanKernelOrder
     (LambdaT lore)
     (LambdaT lore)
     [SubExp]
@@ -112,10 +110,6 @@ data KernelSize = KernelSize { kernelWorkgroups :: SubExp
                              , kernelNumThreads :: SubExp
                              }
                 deriving (Eq, Ord, Show)
-
-data ScanKernelOrder = ScanTransposed
-                     | ScanFlat
-                     deriving (Eq, Ord, Show)
 
 -- | Like 'Mapper', but just for 'Kernel's.
 data KernelMapper flore tlore m = KernelMapper {
@@ -162,12 +156,11 @@ mapKernelM tv (ReduceKernel cs w kernel_size comm red_fun fold_fun arrs) =
   mapOnKernelLambda tv red_fun <*>
   mapOnKernelLambda tv fold_fun <*>
   mapM (mapOnKernelVName tv) arrs
-mapKernelM tv (ScanKernel cs w kernel_size order fun fold_fun nes arrs) =
+mapKernelM tv (ScanKernel cs w kernel_size fun fold_fun nes arrs) =
   ScanKernel <$>
   mapOnKernelCertificates tv cs <*>
   mapOnKernelSubExp tv w <*>
   mapOnKernelSize tv kernel_size <*>
-  pure order <*>
   mapOnKernelLambda tv fun <*>
   mapOnKernelLambda tv fold_fun <*>
   mapM (mapOnKernelSubExp tv) nes <*>
@@ -297,11 +290,10 @@ kernelType (ReduceKernel _ _ size _ redlam foldlam _) =
       arr_row_tp = drop (length acc_tp) $ lambdaReturnType foldlam
   in acc_tp ++
      map (`setOuterSize` kernelTotalElements size) arr_row_tp
-kernelType (ScanKernel _ w size _ lam foldlam nes _) =
+kernelType (ScanKernel _ w size lam foldlam nes _) =
   let arr_row_tp = drop (length nes) $ lambdaReturnType foldlam
   in map (`arrayOfRow` w) (lambdaReturnType lam) ++
-     map ((`arrayOfRow` kernelWorkgroups size) .
-          (`arrayOfRow` kernelWorkgroupSize size)) (lambdaReturnType lam) ++
+     map (`arrayOfRow` kernelWorkgroups size) (lambdaReturnType lam) ++
      map (`setOuterSize` kernelTotalElements size) arr_row_tp
 kernelType (ChunkedMapKernel _ _ size _ fun _) =
   map (`arrayOfRow` kernelNumThreads size) nonconcat_ret <>
@@ -379,7 +371,7 @@ instance (Attributes lore, CanBeWise (Op lore)) => CanBeWise (Kernel lore) where
 instance (Aliased lore, UsageInOp (Op lore)) => UsageInOp (Kernel lore) where
   usageInOp (ReduceKernel _ _ _ _ _ foldfun arrs) =
     usageInLambda foldfun arrs
-  usageInOp (ScanKernel _ _ _ _ _ foldfun _ arrs) =
+  usageInOp (ScanKernel _ _ _ _ foldfun _ arrs) =
     usageInLambda foldfun arrs
   usageInOp (ChunkedMapKernel _ _ _ _ fun arrs) =
     usageInLambda fun arrs
@@ -468,7 +460,7 @@ typeCheckKernel (ReduceKernel cs w kernel_size _ parfun seqfun arrexps) = do
     TC.bad $ TC.TypeError $ "Initial value is of type " ++ prettyTuple redt ++
           ", but redomap fold function returns type " ++ prettyTuple fold_acc_ret ++ "."
 
-typeCheckKernel (ScanKernel cs w kernel_size _ fun foldfun nes arrs) = do
+typeCheckKernel (ScanKernel cs w kernel_size fun foldfun nes arrs) = do
   checkKernelCrud cs w kernel_size
 
   let index_arg = (Prim int32, mempty)
@@ -578,7 +570,7 @@ instance OpMetrics (Op lore) => OpMetrics (Kernel lore) where
     inside "MapKernel" $ bodyMetrics body
   opMetrics (ReduceKernel _ _ _ _ lam1 lam2 _) =
     inside "ReduceKernel" $ lambdaMetrics lam1 >> lambdaMetrics lam2
-  opMetrics (ScanKernel _ _ _ _ lam foldfun _ _) =
+  opMetrics (ScanKernel _ _ _ lam foldfun _ _) =
     inside "ScanKernel" $ lambdaMetrics lam >> lambdaMetrics foldfun
   opMetrics (ChunkedMapKernel _ _ _ _ fun _) =
     inside "ChunkedMapKernel" $ lambdaMetrics fun
@@ -608,11 +600,10 @@ instance PrettyLore lore => PP.Pretty (Kernel lore) where
             commasep (map ppr as) <> comma </>
             ppr comm </>
             ppr parfun <> comma </> ppr seqfun)
-  ppr (ScanKernel cs w kernel_size order fun foldfun nes arrs) =
+  ppr (ScanKernel cs w kernel_size fun foldfun nes arrs) =
     ppCertificates' cs <> text "scanKernel" <>
     parens (ppr w <> comma </>
             ppr kernel_size <> comma </>
-            ppr order <> comma </>
             PP.braces (commasep $ map ppr nes) <> comma </>
             commasep (map ppr arrs) <> comma </>
             ppr fun <> comma </> ppr foldfun)
@@ -640,10 +631,6 @@ instance Pretty KernelSize where
                           ppr offset_multiple,
                           ppr num_threads
                          ]
-
-instance Pretty ScanKernelOrder where
-  ppr ScanFlat = text "flat"
-  ppr ScanTransposed = text "transposed"
 
 instance PrettyLore lore => Pretty (KernelInput lore) where
   ppr inp = ppr (kernelInputType inp) <+>


### PR DESCRIPTION
Fixes #176 .

There is still room for improvement.  Thrust uses a technique where every thread processes several elements, not just one.  We could do that as well, at the cost of using more local memory.