### PR TITLE
Add git info to --version

### DIFF
--- a/futhark.cabal
+++ b/futhark.cabal
@@ -51,7 +51,8 @@ Library
                  neat-interpolation >= 0.3,
                  file-embed >= 0.0.9,
                  directory,
-                 directory-tree
+                 directory-tree,
+                 gitrev >= 1.2.0
 
   Exposed-modules: Futhark.Actions
                    Futhark.Analysis.AlgSimplify

--- a/src/Futhark/Version.hs
+++ b/src/Futhark/Version.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE TemplateHaskell #-}
 -- | This module exports version information about the Futhark
 -- compiler.
 module Futhark.Version
@@ -8,6 +9,7 @@ module Futhark.Version
        where
 
 import Data.Version
+import Development.GitRev
 
 import qualified Paths_futhark
 
@@ -18,4 +20,15 @@ version = Paths_futhark.version
 
 -- | The version of Futhark that we are using, as a 'String'
 versionString :: String
-versionString = showVersion version
+versionString = showVersion version ++ "\n" ++ gitversion
+  where
+    gitversion = concat ["git: "
+                        , branch
+                        , take 7 $(gitHash)
+                        , " (", $(gitCommitDate), ")"
+                        , dirty
+                        ]
+    branch | $(gitBranch) == "master" = ""
+           | otherwise = $(gitBranch) ++ " @ "
+    dirty | $(gitDirty) = " [modified]"
+          | otherwise   = ""

--- a/stack-lts-1.15.yaml
+++ b/stack-lts-1.15.yaml
@@ -56,4 +56,5 @@ extra-deps:
 - xml-1.3.14
 - alex-3.1.7
 - json-0.9.1
+- gitrev-1.2.0
 resolver: lts-1.15


### PR DESCRIPTION
Output of `futhark --version` will now be like the following. I think the format for the timestamp of the commit is horrible, but I do think it is important to have, as it tells you how recent a version was used which is usually what you want to know for non debugging purposes. 

```
Futhark 0.1
git: 8791fd4 (Wed Jan 11 18:26:23 2017 +0100)
(C) HIPERFIT research centre
Department of Computer Science, University of Copenhagen (DIKU)
```

If the branch is not "master", the branchname will be inserted before the hash, and if any files have been modified this will be displayed at the end of the line

# Caveats 

Due to the way the `gitrev` package works (using TemplateHaskell),
`Futhark.Version` and `Futhark.Util.Options` will be recompiled on *every*
compilation. This kinda sucks, and is why I didn't just merge it right away.