### PR TITLE
Don't manifest arrays in isSegmentedOp when extracting kernels

### DIFF
--- a/src/Futhark/Pass/ExtractKernels.hs
+++ b/src/Futhark/Pass/ExtractKernels.hs
@@ -1010,10 +1010,8 @@ isSegmentedOp nest perm segment_size ret free_in_op _free_in_fold_op nes arrs m 
           -- reproduce the parameter type.
           let reshape = reshapeOuter [DimNew total_num_elements]
                         (2+length (snd nest)) arr_shape
-          arr_manifest <- letExp (baseString arr ++ "_manifest") $
-                          BasicOp $ Copy arr
           letExp (baseString arr ++ "_flat") $
-            BasicOp $ Reshape [] reshape arr_manifest
+            BasicOp $ Reshape [] reshape arr
 
     arrs' <- mapM flatten =<< sequence mk_arrs
 


### PR DESCRIPTION
Just wanted your approval before commiting this to master. Seems like things
could break from this change, but I ran both the testsuite and the benchmarks,
and nothing showed up.

I ran the testsuite with `$ futhark-test --only-compile --compiler='futhark-opencl' tests`
this gives the same errors both with and without this change in the following files

```
tests/array14-running-example.fut
tests/distribution/distribution7.fut
tests/flattening/IntmRes4.fut
tests/distribution/irregular1.fut
tests/issue194.fut
tests/shapes/lambda-return.fut
tests/soacs/map11.fut
tests/soacs/scan2.fut
tests/vasicek/iobound-mc2.fut
```