### PR TITLE
Clean up python RTS reader

### DIFF
--- a/rts/python/reader.py
+++ b/rts/python/reader.py
@@ -163,9 +163,6 @@ def read_double(f):
     optional(read_float_trailer, f)
     return float(sign + bef + '.' + aft + 'E' + expt)
 
-def read_float(f):
-    return read_double(f)
-
 def read_float_trailer(f):
   parse_specific_char(f, 'f')
   while peek_char(f).isdigit():
@@ -229,19 +226,6 @@ def verify_array_dims(l, dims):
     if len(dims) > 1:
         for x in l:
             verify_array_dims(x, dims[1:])
-
-def read_double_signed(f):
-
-    skip_spaces(f)
-    c = get_char(f)
-
-    if c == '-' and peek_char(f).isdigit():
-      v = -1 * read_double(f)
-    else:
-      unget_char(f, c)
-      v = read_double(f)
-
-    return v
 
 def read_array(f, elem_reader, type_name, rank, bt):
     elems = read_array_helper(f, elem_reader, type_name, rank)

--- a/src/Futhark/CodeGen/Backends/GenericPython.hs
+++ b/src/Futhark/CodeGen/Backends/GenericPython.hs
@@ -438,11 +438,10 @@ valueDescVName (Imp.ScalarValue _ _ vname) = vname
 valueDescVName (Imp.ArrayValue vname _ _ _ _ _) = vname
 
 readerElem :: PrimType -> Imp.Signedness -> String
-readerElem (FloatType Float32) _ = "read_float"
-readerElem (FloatType Float64) _ = "read_double_signed"
-readerElem IntType{} _           = "read_int"
-readerElem Bool _                = "read_bool"
-readerElem Cert _                = error "Cert is never used. ReaderElem doesn't handle this"
+readerElem (FloatType _) _ = "read_double"
+readerElem IntType{} _     = "read_int"
+readerElem Bool _          = "read_bool"
+readerElem Cert _          = error "Cert is never used. ReaderElem doesn't handle this"
 
 readInput :: Imp.ExternalValue -> PyStmt
 readInput (Imp.OpaqueValue desc _) =

--- a/src/Futhark/CodeGen/Backends/GenericPython/Definitions.hs
+++ b/src/Futhark/CodeGen/Backends/GenericPython/Definitions.hs
@@ -2,7 +2,7 @@
 module Futhark.CodeGen.Backends.GenericPython.Definitions
   ( pyFunctions
   , pyUtility
-  , pyTestMain
+  , pyReader
   ) where
 
 import Data.FileEmbed
@@ -13,5 +13,5 @@ pyFunctions = $(embedStringFile "rts/python/memory.py")
 pyUtility :: String
 pyUtility = $(embedStringFile "rts/python/scalar.py")
 
-pyTestMain :: String
-pyTestMain = $(embedStringFile "rts/python/reader.py")
+pyReader :: String
+pyReader = $(embedStringFile "rts/python/reader.py")

--- a/src/Futhark/CodeGen/Backends/PyOpenCL.hs
+++ b/src/Futhark/CodeGen/Backends/PyOpenCL.hs
@@ -39,7 +39,7 @@ compileProg module_name prog = do
              Assign (Var "preferred_platform") None,
              Assign (Var "preferred_device") None,
              Assign (Var "fut_opencl_src") $ RawStringLiteral $ opencl_prelude ++ opencl_code,
-             Escape pyTestMain,
+             Escape pyReader,
              Escape pyFunctions]
       let imports = [Import "sys" Nothing,
                      Import "numpy" $ Just "np",

--- a/src/Futhark/CodeGen/Backends/SequentialPython.hs
+++ b/src/Futhark/CodeGen/Backends/SequentialPython.hs
@@ -28,7 +28,7 @@ compileProg module_name =
                    Import "numpy" $ Just "np",
                    Import "ctypes" $ Just "ct",
                    Import "time" Nothing]
-        defines = [Escape pyTestMain, Escape pyFunctions]
+        defines = [Escape pyReader, Escape pyFunctions]
         operations :: GenericPython.Operations Imp.Sequential ()
         operations = GenericPython.defaultOperations {
           GenericPython.opsCompiler = const $ return ()


### PR DESCRIPTION
`read_double_signed` was used to read `f64`, but reading `f32` did not use this function, but just `read_double`.

Wanted to make sure there was no reason for handling negative numbers twice for `f64` and not doing so for `f32`, so that is why I made the pull request.