### PR TITLE
[add] fucolor utility: colorize vars in futhark output

### DIFF
--- a/tools/futcolor
+++ b/tools/futcolor
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+
+"""
+A small utility to colorize variable names in Futhark output.
+"""
+
+import re
+from sys import stdin, argv
+
+# All Futhark-generated variables have this form
+var = re.compile(r'[\w_]+_\d+')
+
+
+if __name__ == "__main__":
+    args = argv[1:]
+    if len(args) == 0:
+        files = [stdin]
+    else:
+        files = map(open, args)
+
+    for f in files:
+        content = f.read()
+        all_vars = var.findall(content)
+        all_vars = sorted(set(all_vars), key=all_vars.index)
+        for i, v in enumerate(all_vars):
+            color = (7*i) % 256
+            colored_v = "\033[38;5;{}m{}\033[0m".format(color, v)
+            content = content.replace(v, colored_v)
+        print(content)


### PR DESCRIPTION
As a human, I find it easier to read Futhark output with (generated) variable names in colorz.

Works well in 256-colors terminals, with all kind of futhark outputs (C/py OpenCL, futhark IL, ...)

![2017-03-13-115733_911x1365_scrot](https://cloud.githubusercontent.com/assets/245617/23877919/eee67d04-0844-11e7-80e3-b679b6a3ad3f.png)
