### PR TITLE
Fix integer division in the Python backend.

### DIFF
--- a/rts/python/scalar.py
+++ b/rts/python/scalar.py
@@ -29,13 +29,13 @@ def ashrN(x,y):
   return x >> y
 
 def sdivN(x,y):
-  return x / y
+  return x // y
 
 def smodN(x,y):
   return x % y
 
 def udivN(x,y):
-  return signed(unsigned(x) / unsigned(y))
+  return signed(unsigned(x) // unsigned(y))
 
 def umodN(x,y):
   return signed(unsigned(x) % unsigned(y))

--- a/tests/size-from-division.fut
+++ b/tests/size-from-division.fut
@@ -1,0 +1,10 @@
+-- The array size is the result of a division.
+--
+-- This was a problem with futhark-py and futhark-pyopencl due to the magic '/'
+-- Python 3 division operator.
+-- ==
+-- input { 5 2 }
+-- output { [0, 1] }
+
+let main (x: i32, y: i32): []i32 =
+  iota (x / y)


### PR DESCRIPTION
Previously, division of two integers could result in a float.