### PR TITLE
Add implicit prelude to Futhark programs.

### DIFF
--- a/futlib/array.fut
+++ b/futlib/array.fut
@@ -32,13 +32,30 @@ let reverse [n] 't (x: [n]t): [n]t = x[::-1]
 -- | Replace an element of the array with a new value.
 let update [n] 't (xs: *[n]t) (i: i32) (x: t): [n]t = xs with [i] <- x
 
-let pick [n] 't (flags: [n]bool) (xs: [n]t) (ys: [n]t): [n]t =
+-- | Construct an array of consecutive integers of the given length,
+-- starting at 0.
+let iota (n: i32): *[n]i32 =
+  i32.iota n
+
+-- | Construct an array of the given length containing the given
+-- value.
+let replicate 't (n: i32) (x: t): *[n]t =
+  i32.replicate n x
+
+-- | Copy an array.
+let copy [n] 't (a: [n]t): *[n]t =
+  map (\x -> x) a
+
+let scatter 't [m] [n] (dest: *[m]t) (is: [n]i32) (vs: [n]t): *[m]t =
+  intrinsics.scatter dest is vs
+
+let pick [n] 't (flags: [n]bool) (xs: [n]t) (ys: [n]t): *[n]t =
   map (\flag x y -> if flag then x else y) flags xs ys
 
 let flatten [n] [m] 't (xs: [n][m]t): []t =
   reshape (n*m) xs
 
-let intersperse [n] 't (x: t) (xs: [n]t): []t =
+let intersperse [n] 't (x: t) (xs: [n]t): *[]t =
   map (\i -> if i % 2 == 1 && i != 2*n then x
              else unsafe xs[i/2])
       (iota (i32.max (2*n-1) 0))
@@ -48,9 +65,6 @@ let intercalate [n] [m] 't (x: [m]t) (xs: [n][m]t): []t =
 
 let transpose [n] [m] 't (a: [n][m]t): [m][n]t =
   rearrange (1,0) a
-
-let copy [n] 't (a: [n]t): *[n]t =
-  map (\x -> x) a
 
 let steps (start: i32) (num_steps: i32) (step: i32): [num_steps]i32 =
   map (start+) (map (step*) (iota num_steps))

--- a/futlib/math.fut
+++ b/futlib/math.fut
@@ -1,3 +1,5 @@
+local let const 'a 'b (x: a) (_: b): a = x
+
 module type numeric = {
   type t
 
@@ -123,8 +125,8 @@ module i8: (size with t = i8) = {
   let max (x: t) (y: t) = intrinsics.smax8 x y
   let min (x: t) (y: t) = intrinsics.smin8 x y
 
-  let iota (n: i8) = intrinsics.iota_i8 n
-  let replicate 'v (n: i8) (x: v) = intrinsics.replicate (i32 n) x
+  let iota (n: i8) = [0i8..1i8..<n]
+  let replicate 'v (n: i8) (x: v) = map (const x) (iota n)
 }
 
 module i16: (size with t = i16) = {
@@ -165,8 +167,8 @@ module i16: (size with t = i16) = {
   let max (x: t) (y: t) = intrinsics.smax16 x y
   let min (x: t) (y: t) = intrinsics.smin16 x y
 
-  let iota (n: i16) = intrinsics.iota_i16 n
-  let replicate 'v (n: i16) (x: v) = intrinsics.replicate (i32 n) x
+  let iota (n: i16) = [0i16..1i16..<n]
+  let replicate 'v (n: i16) (x: v) = map (const x) (iota n)
 }
 
 module i32: (size with t = i32) = {
@@ -207,8 +209,8 @@ module i32: (size with t = i32) = {
   let max (x: t) (y: t) = intrinsics.smax32 x y
   let min (x: t) (y: t) = intrinsics.smin32 x y
 
-  let iota (n: i32) = intrinsics.iota_i32 n
-  let replicate 'v (n: i32) (x: v) = intrinsics.replicate (i32 n) x
+  let iota (n: i32) = [0..1..<n]
+  let replicate 'v (n: i32) (x: v) = map (const x) (iota n)
 }
 
 module i64: (size with t = i64) = {
@@ -249,8 +251,8 @@ module i64: (size with t = i64) = {
   let max (x: t) (y: t) = intrinsics.smax64 x y
   let min (x: t) (y: t) = intrinsics.smin64 x y
 
-  let iota (n: i64) = intrinsics.iota_i64 n
-  let replicate 'v (n: i64) (x: v) = intrinsics.replicate (i32 n) x
+  let iota (n: i64) = [0i64..1i64..<n]
+  let replicate 'v (n: i64) (x: v) = map (const x) (iota n)
 }
 
 module u8: (size with t = u8) = {
@@ -291,8 +293,8 @@ module u8: (size with t = u8) = {
   let max (x: t) (y: t) = u8 (intrinsics.umax8 (i8 x) (i8 y))
   let min (x: t) (y: t) = u8 (intrinsics.umin8 (i8 x) (i8 y))
 
-  let iota (n: u8) = intrinsics.iota_u8 n
-  let replicate 'v (n: u8) (x: v) = intrinsics.replicate (i32 n) x
+  let iota (n: u8) = [0u8..1u8..<n]
+  let replicate 'v (n: u8) (x: v) = map (const x) (iota n)
 }
 
 module u16: (size with t = u16) = {
@@ -333,8 +335,8 @@ module u16: (size with t = u16) = {
   let max (x: t) (y: t) = u16 (intrinsics.umax16 (i16 x) (i16 y))
   let min (x: t) (y: t) = u16 (intrinsics.umin16 (i16 x) (i16 y))
 
-  let iota (n: u16) = intrinsics.iota_u16 n
-  let replicate 'v (n: u16) (x: v) = intrinsics.replicate (i32 n) x
+  let iota (n: u16) = [0u16..1u16..<n]
+  let replicate 'v (n: u16) (x: v) = map (const x) (iota n)
 }
 
 module u32: (size with t = u32) = {
@@ -375,8 +377,8 @@ module u32: (size with t = u32) = {
   let max (x: t) (y: t) = u32 (intrinsics.umax32 (i32 x) (i32 y))
   let min (x: t) (y: t) = u32 (intrinsics.umin32 (i32 x) (i32 y))
 
-  let iota (n: u32) = intrinsics.iota_u32 n
-  let replicate 'v (n: u32) (x: v) = intrinsics.replicate (i32 n) x
+  let iota (n: u32) = [0u32..1u32..<n]
+  let replicate 'v (n: u32) (x: v) = map (const x) (iota n)
 }
 
 module u64: (size with t = u64) = {
@@ -417,8 +419,8 @@ module u64: (size with t = u64) = {
   let max (x: t) (y: t) = u64 (intrinsics.umax64 (i64 x) (i64 y))
   let min (x: t) (y: t) = u64 (intrinsics.umin64 (i64 x) (i64 y))
 
-  let iota (n: u64) = intrinsics.iota_u64 n
-  let replicate 'v (n: u64) (x: v) = intrinsics.replicate (i32 n) x
+  let iota (n: u64) = [0u64..1u64..<n]
+  let replicate 'v (n: u64) (x: v) = map (const x) (iota n)
 }
 
 module f64: (real with t = f64) = {

--- a/futlib/prelude.fut
+++ b/futlib/prelude.fut
@@ -1,0 +1,7 @@
+-- Note: this file is known to the compiler, and along with its
+-- dependencies, it is embedded into the (compiler) binary.  Make sure
+-- it does not depend on anything too big to be serialised
+-- efficiently.
+
+open import "/futlib/array"
+open import "/futlib/math"

--- a/package.yaml
+++ b/package.yaml
@@ -45,6 +45,8 @@ dependencies:
   - parallel >= 3.2.1.0
   - bifunctors
   - blaze-html
+  - template-haskell
+  - th-lift-instances
 
 library:
   build-tools:

--- a/src/Futhark/Compiler/TH.hs
+++ b/src/Futhark/Compiler/TH.hs
@@ -1,0 +1,41 @@
+-- | Wrappers around "Futhark.Compiler" to provide functionality
+-- useful for Template Haskell.
+module Futhark.Compiler.TH
+  (embedBasis)
+where
+
+import Control.Monad.Except (runExceptT)
+import Language.Futhark.TH ()
+import Language.Haskell.TH.Syntax (Exp, Q, runIO, lift, qAddDependentFile)
+import System.FilePath
+
+import Futhark.Compiler
+import Futhark.Util (directoryContents)
+
+futFiles :: FilePath -> IO [FilePath]
+futFiles dir = filter isFut <$> directoryContents dir
+  where isFut = (==".fut") . takeExtension
+
+readBasis :: FilePath -> String -> Q Basis
+readBasis fpath entry = do
+  files <- runIO $ futFiles fpath
+
+  -- In many cases, the 'fpath' may be only a single file, which
+  -- imports others.  We will assume that all .fut files in the
+  -- containing directory may influence for dependency information.
+  -- Even if we get this wrong, it only means we'll do a few
+  -- unnecessary recompiles.
+  all_files <- runIO $ futFiles $ takeDirectory fpath
+  mapM_ qAddDependentFile all_files
+
+  res <- runIO $ runExceptT $ readProgram emptyBasis files
+  case res of
+    Right (_, _, imps, src) ->
+      return $ Basis imps src [entry]
+    Left err -> error $ show err
+
+-- | At compile-time, produce an 'Exp' corresponding to a 'Basis'.
+-- The 'FilePath' must refer to a @.fut@ file.
+embedBasis :: FilePath -> String -> Q Exp
+embedBasis fpath entry =
+  lift =<< readBasis fpath entry

--- a/src/Futhark/Doc/Generator.hs
+++ b/src/Futhark/Doc/Generator.hs
@@ -79,7 +79,7 @@ prettyFun fm (FunBind _ name _retdecl _rettype _tparams _args _ doc _)
     renderDoc doc <> "val " <> vnameHtml name <>
     foldMap (" " <>) (map prettyTypeParam tps) <> ": " <>
     foldMap (\t -> prettyType t <> " -> ") pts <> prettyType rett
-    where FileModule Env {envVtable = vtable} = fm
+    where FileModule Env {envVtable = vtable} _ = fm
 prettyFun _ _ = Nothing
 
 prettyVal :: FileModule -> ValBindBase Info VName -> Maybe (DocM Html)
@@ -89,7 +89,7 @@ prettyVal fm (ValBind _entry name maybe_t _ _e doc _)
     Just . return . H.div $
     renderDoc doc <> "let " <> vnameHtml name <> " : " <>
     maybe (prettyType st) typeExpHtml maybe_t
-    where (FileModule Env {envVtable = vtable}) = fm
+    where (FileModule Env {envVtable = vtable} _) = fm
 prettyVal _ _ = Nothing
 
 prettySig :: FileModule -> SigBindBase Info VName -> Maybe (DocM Html)
@@ -100,7 +100,7 @@ prettySig fm (SigBind vname se doc _)
       expHtml <- renderSigExp se
       return $ renderDoc doc <> "module type " <> name <>
         " = " <> expHtml
-    where (FileModule Env { envSigTable = sigtable }) = fm
+    where (FileModule Env { envSigTable = sigtable } _) = fm
 prettySig _ _ = Nothing
 
 prettyMod :: FileModule -> ModBindBase Info VName -> Maybe (DocM Html)
@@ -112,7 +112,7 @@ prettyMod fm (ModBind name ps sig _me doc _)
     s <- case sig of Nothing -> envSig env
                      Just (s,_) -> renderSigExp s
     return $ renderDoc doc <> "module " <> vname <> ": " <> params <> s
-    where FileModule Env { envModTable = modtable} = fm
+    where FileModule Env { envModTable = modtable} _ = fm
           envSig (ModEnv e) = renderEnv e
           envSig (ModFun (FunSig _ _ (MTy _ m))) = envSig m
 prettyMod _ _ = Nothing
@@ -121,7 +121,7 @@ renderType :: FileModule -> TypeBindBase Info VName -> Maybe (DocM Html)
 renderType fm tb
   | M.member name typeTable
   , visible Type name fm = Just $ H.div <$> typeBindHtml tb
-    where (FileModule Env {envTypeTable = typeTable}) = fm
+    where (FileModule Env {envTypeTable = typeTable} _) = fm
           TypeBind { typeAlias = name } = tb
 renderType _ _ = Nothing
 
@@ -141,7 +141,7 @@ _ = let
   in renderModExp
 
 visible :: Namespace -> VName -> FileModule -> Bool
-visible ns vname@(VName name _) (FileModule env)
+visible ns vname@(VName name _) (FileModule env _)
   | Just vname' <- M.lookup (ns,name) (envNameMap env)
   = vname == vname'
 visible _ _ _ = False

--- a/src/Futhark/FreshNames.hs
+++ b/src/Futhark/FreshNames.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DeriveLift #-}
 -- | This module provides facilities for generating unique names.
 module Futhark.FreshNames
   ( VNameSource
@@ -8,6 +9,8 @@ module Futhark.FreshNames
   , newVNameFromName
   ) where
 
+import Language.Haskell.TH.Syntax (Lift)
+
 import Language.Futhark.Core
 
 -- | A name source is conceptually an infinite sequence of names with
@@ -15,6 +18,7 @@ import Language.Futhark.Core
 -- source will return the name along with a new name source, which
 -- should then be used in place of the original.
 newtype VNameSource = VNameSource Int
+  deriving (Lift)
 
 instance Monoid VNameSource where
   mempty = blankNameSource

--- a/src/Futhark/Optimise/Simplifier/Rules.hs
+++ b/src/Futhark/Optimise/Simplifier/Rules.hs
@@ -904,8 +904,9 @@ simplifyConcat _ _ =
   cannotSimplify
 
 evaluateBranch :: MonadBinder m => TopDownRule m
-evaluateBranch _ (Let pat _ (If e1 tb fb (IfAttr t _)))
-  | Just branch <- checkBranch = do
+evaluateBranch _ (Let pat _ (If e1 tb fb (IfAttr t ifsort)))
+  | Just branch <- checkBranch,
+    ifsort /= IfFallback || isCt1 e1 = do
   let ses = bodyResult branch
   mapM_ addStm $ bodyStms branch
   ctx <- subExpShapeContext t ses

--- a/src/Language/Futhark/Attributes.hs
+++ b/src/Language/Futhark/Attributes.hs
@@ -826,8 +826,6 @@ intrinsics = M.fromList $ zipWith namify [10..] $
              -- The reason for the loop formulation is to ensure that we
              -- get a missing case warning if we forget a case.
              map mkIntrinsicBinOp [minBound..maxBound] ++
-             map mkIota (map Signed [minBound..maxBound] ++
-                         map Unsigned [minBound..maxBound]) ++
 
              [("scatter", IntrinsicPolyFun [tp_a]
                           [Array $ PolyArray tv_a' [] (Rank 1) Unique (),
@@ -836,12 +834,7 @@ intrinsics = M.fromList $ zipWith namify [10..] $
                           Array $ PolyArray tv_a' [] (Rank 1) Unique ()),
               ("shape", IntrinsicPolyFun [tp_a]
                         [Array $ PolyArray tv_a' [] (Rank 1) Nonunique ()] $
-                        Array $ PrimArray (Signed Int32) (Rank 1) Unique ()),
-              ("replicate", IntrinsicPolyFun [tp_a]
-                            [Prim $ Signed Int32, TypeVar tv_a' []] $
-                            Array $ PolyArray tv_a' [] (Rank 1) Unique ()),
-              ("iota", IntrinsicPolyFun [] [Prim $ Signed Int32] $
-                       Array $ PrimArray (Signed Int32) (Rank 1) Unique ())]
+                        Array $ PrimArray (Signed Int32) (Rank 1) Unique ())]
 
   where tv_a = VName (nameFromString "a") 0
         tv_a' = typeName tv_a
@@ -904,10 +897,6 @@ intrinsics = M.fromList $ zipWith namify [10..] $
         intrinsicBinOp Geq      = ordering
 
         ordering = IntrinsicOverloadedFun [ ([t,t], Bool) | t <- anyPrimType ]
-
-        mkIota t = ("iota_" ++ pretty t,
-                    IntrinsicPolyFun [] [Prim t] $
-                    Array $ PrimArray t (Rank 1) Unique ())
 
 -- | The largest tag used by an intrinsic - this can be used to
 -- determine whether a 'VName' refers to an intrinsic or a user-defined name.

--- a/src/Language/Futhark/Core.hs
+++ b/src/Language/Futhark/Core.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DeriveLift         #-}
 -- | This module contains very basic definitions for Futhark - so basic,
 -- that they can be shared between the internal and external
 -- representation.
@@ -37,6 +38,8 @@ import Data.Word (Word8, Word16, Word32, Word64)
 import Data.Loc
 import Data.List
 import qualified Data.Text as T
+import Language.Haskell.TH.Syntax (Lift)
+import Instances.TH.Lift()
 
 import Prelude
 
@@ -47,7 +50,7 @@ import Futhark.Util.Pretty
 -- to ordering, 'Unique' is greater than 'Nonunique'.
 data Uniqueness = Nonunique -- ^ May have references outside current function.
                 | Unique    -- ^ No references outside current function.
-                  deriving (Eq, Ord, Show)
+                  deriving (Eq, Ord, Show, Lift)
 
 instance Monoid Uniqueness where
   mempty = Unique
@@ -65,13 +68,13 @@ instance Hashable Uniqueness where
 
 data StreamOrd  = InOrder
                 | Disorder
-                    deriving (Eq, Ord, Show)
+                    deriving (Eq, Ord, Show, Lift)
 
 -- | Whether some operator is commutative or not.  The 'Monoid'
 -- instance returns the least commutative of its arguments.
 data Commutativity = Noncommutative
                    | Commutative
-                     deriving (Eq, Ord, Show)
+                     deriving (Eq, Ord, Show, Lift)
 
 instance Monoid Commutativity where
   mempty = Commutative
@@ -85,7 +88,7 @@ defaultEntryPoint = nameFromString "main"
 -- compiler.  'String's, being lists of characters, are very slow,
 -- while 'T.Text's are based on byte-arrays.
 newtype Name = Name T.Text
-  deriving (Show, Eq, Ord)
+  deriving (Show, Eq, Ord, Lift)
 
 instance Pretty Name where
   ppr = text . nameToString
@@ -126,7 +129,7 @@ locStr (SrcLoc (Loc (Pos file line1 col1 _) (Pos _ line2 col2 _))) =
 -- | A name tagged with some integer.  Only the integer is used in
 -- comparisons, no matter the type of @vn@.
 data VName = VName !Name !Int
-  deriving (Show)
+  deriving (Show, Lift)
 
 -- | Return the tag contained in the 'VName'.
 baseTag :: VName -> Int

--- a/src/Language/Futhark/Futlib.hs
+++ b/src/Language/Futhark/Futlib.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE TemplateHaskell #-}
--- | The Futhark standard library embedded as strings read during
+-- | The Futhark basis library embedded embedded as strings read during
 -- compilation of the Futhark compiler.  The advantage is that the
 -- standard library can be accessed without reading it from disk, thus
 -- saving users from include path headaches.
@@ -12,6 +12,7 @@ import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
 import System.FilePath
 
+-- | Futlib embedded as 'T.Text' values, one for every file.
 futlib :: [(FilePath, T.Text)]
 futlib = map fixup futlib_bs
   where futlib_bs = $(embedDir "futlib")

--- a/src/Language/Futhark/Futlib/Prelude.hs
+++ b/src/Language/Futhark/Futlib/Prelude.hs
@@ -1,0 +1,17 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE TemplateHaskell #-}
+-- | The Futhark prelude embedded into the Futhark compiler.  This
+-- means we do not have to parse and type-check it whenever we compile
+-- a Futhark program.
+module Language.Futhark.Futlib.Prelude (preludeBasis) where
+
+import Futhark.Compiler
+import Futhark.Compiler.TH
+import Language.Futhark.Futlib()
+
+-- | The Futlib basis constructed from @futlib/prelude.fut@.  This is
+-- only a subset of the full futlib, but contains pre-type checked
+-- ASTs.
+preludeBasis :: Basis
+preludeBasis = $(embedBasis "futlib/prelude.fut" "/futlib/prelude")

--- a/src/Language/Futhark/TH.hs
+++ b/src/Language/Futhark/TH.hs
@@ -1,0 +1,80 @@
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+{-# LANGUAGE DeriveLift         #-}
+{-# LANGUAGE FlexibleInstances  #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE Strict             #-}
+-- | Template Haskell instances for AST and type checker types.
+module Language.Futhark.TH () where
+
+
+import           Data.Loc
+import           Instances.TH.Lift                  ()
+import           Language.Haskell.TH.Syntax         (Lift)
+
+import           Language.Futhark.Core
+import           Language.Futhark.Syntax
+import           Language.Futhark.TypeChecker
+import           Language.Futhark.TypeChecker.Monad
+
+-- Instances for things from non-Futhark packages
+deriving instance Lift Pos
+deriving instance Lift Loc
+deriving instance Lift SrcLoc
+
+-- Generic AST instances
+deriving instance Lift a => Lift (Info a)
+deriving instance Lift (NoInfo a)
+deriving instance Lift a => Lift (QualName a)
+deriving instance Lift a => Lift (DimDecl a)
+deriving instance Lift a => Lift (TypeArgExp a)
+deriving instance Lift a => Lift (TypeExp a)
+deriving instance Lift Rank
+deriving instance Lift TypeName
+deriving instance Lift IntType
+deriving instance Lift FloatType
+deriving instance Lift PrimType
+deriving instance (Lift a, Lift b) => Lift (TypeArg a b)
+deriving instance (Lift a, Lift b) => Lift (RecordArrayElemTypeBase a b)
+deriving instance (Lift a, Lift b) => Lift (ArrayTypeBase a b)
+deriving instance (Lift a, Lift b) => Lift (TypeBase a b)
+deriving instance Lift a => Lift (ShapeDecl a)
+deriving instance Lift a => Lift (Inclusiveness a)
+deriving instance Lift IntValue
+deriving instance Lift FloatValue
+deriving instance Lift PrimValue
+deriving instance Lift Diet
+
+-- Checked AST instances
+deriving instance Lift (TypeDeclBase Info VName)
+deriving instance Lift (IdentBase Info VName)
+deriving instance Lift (PatternBase Info VName)
+deriving instance Lift (ValBindBase Info VName)
+deriving instance Lift (FieldBase Info VName)
+deriving instance Lift (LoopFormBase Info VName)
+deriving instance Lift (DimIndexBase Info VName)
+deriving instance Lift (TypeParamBase VName)
+deriving instance Lift (LambdaBase Info VName)
+deriving instance Lift (StreamForm Info VName)
+deriving instance Lift (ExpBase Info VName)
+deriving instance Lift (FunBindBase Info VName)
+deriving instance Lift (TypeBindBase Info VName)
+deriving instance Lift (ParamBase Info VName)
+deriving instance Lift (SpecBase Info VName)
+deriving instance Lift (TypeRefBase Info VName)
+deriving instance Lift (SigExpBase Info VName)
+deriving instance Lift (SigBindBase Info VName)
+deriving instance Lift (ModParamBase Info VName)
+deriving instance Lift (ModExpBase Info VName)
+deriving instance Lift (ModBindBase Info VName)
+deriving instance Lift (DecBase Info VName)
+deriving instance Lift (ProgBase Info VName)
+
+-- Typechecker instances
+deriving instance Lift ValBinding
+deriving instance Lift TypeBinding
+deriving instance Lift MTy
+deriving instance Lift FunSig
+deriving instance Lift Mod
+deriving instance Lift Namespace
+deriving instance Lift Env
+deriving instance Lift FileModule

--- a/src/Language/Futhark/TypeChecker/Monad.hs
+++ b/src/Language/Futhark/TypeChecker/Monad.hs
@@ -453,5 +453,5 @@ topLevelNameMap = M.filterWithKey (\k _ -> atTopLevel k) intrinsicsNameMap
                 binop_names = S.fromList $ map (nameFromString . pretty)
                               [minBound..(maxBound::BinOp)]
                 unop_names = S.fromList $ map nameFromString ["~", "!"]
-                fun_names = S.fromList $ map nameFromString ["shape", "scatter", "replicate", "iota"]
+                fun_names = S.fromList $ map nameFromString ["shape"]
         atTopLevel _         = False

--- a/src/futhark-c.hs
+++ b/src/futhark-c.hs
@@ -15,6 +15,7 @@ import Futhark.Representation.ExplicitMemory (ExplicitMemory)
 import qualified Futhark.CodeGen.Backends.SequentialC as SequentialC
 import Futhark.Util.Options
 import Futhark.Util.Pretty (prettyText)
+import Language.Futhark.Futlib.Prelude
 
 main :: IO ()
 main = reportingIOErrors $
@@ -24,7 +25,7 @@ main = reportingIOErrors $
 
 compile :: CompilerConfig -> FilePath -> IO ()
 compile config filepath =
-  runCompilerOnProgram (futharkConfig config)
+  runCompilerOnProgram (futharkConfig config) preludeBasis
   sequentialCpuPipeline (cCodeAction filepath config) filepath
 
 cCodeAction :: FilePath -> CompilerConfig -> Action ExplicitMemory

--- a/src/futhark-doc.hs
+++ b/src/futhark-doc.hs
@@ -26,6 +26,7 @@ import Futhark.Compiler (readProgram, dumpError, newFutharkConfig)
 import Futhark.Pipeline (runFutharkM, FutharkM)
 import Futhark.Util.Options
 import Futhark.Util (directoryContents)
+import Language.Futhark.Futlib.Prelude
 
 main :: IO ()
 main = mainWithOptions initialDocConfig commandLineOptions f
@@ -47,7 +48,7 @@ main = mainWithOptions initialDocConfig commandLineOptions f
               exitWith $ ExitFailure 1
             Just outdir -> do
               files <- liftIO $ futFiles dir
-              (Prog prog, _w, imports, _vns) <- readProgram files
+              (Prog prog, _w, imports, _vns) <- readProgram preludeBasis files
               liftIO $ printDecs outdir imports prog
 
 futFiles :: FilePath -> IO [FilePath]

--- a/src/futhark-opencl.hs
+++ b/src/futhark-opencl.hs
@@ -16,6 +16,7 @@ import Futhark.Representation.ExplicitMemory (ExplicitMemory)
 import qualified Futhark.CodeGen.Backends.COpenCL as COpenCL
 import Futhark.Util.Options
 import Futhark.Util.Pretty (prettyText)
+import Language.Futhark.Futlib.Prelude
 
 main :: IO ()
 main = reportingIOErrors $
@@ -25,7 +26,7 @@ main = reportingIOErrors $
 
 compile :: CompilerConfig -> FilePath -> IO ()
 compile config filepath =
-  runCompilerOnProgram (futharkConfig config)
+  runCompilerOnProgram (futharkConfig config) preludeBasis
   gpuPipeline (openclCodeAction filepath config) filepath
 
 openclCodeAction :: FilePath -> CompilerConfig -> Action ExplicitMemory

--- a/src/futhark-py.hs
+++ b/src/futhark-py.hs
@@ -15,6 +15,7 @@ import Futhark.Representation.ExplicitMemory (ExplicitMemory)
 import qualified Futhark.CodeGen.Backends.SequentialPython as SequentialPy
 import Futhark.Util.Options
 import Futhark.Util.Pretty (prettyText)
+import Language.Futhark.Futlib.Prelude
 
 import Prelude
 
@@ -26,7 +27,7 @@ main = reportingIOErrors $
 
 compile :: CompilerConfig -> FilePath -> IO ()
 compile config filepath =
-  runCompilerOnProgram (futharkConfig config)
+  runCompilerOnProgram (futharkConfig config) preludeBasis
   sequentialCpuPipeline (pyCodeAction filepath config) filepath
 
 pyCodeAction :: FilePath -> CompilerConfig -> Action ExplicitMemory

--- a/src/futhark-pyopencl.hs
+++ b/src/futhark-pyopencl.hs
@@ -15,6 +15,7 @@ import Futhark.Representation.ExplicitMemory (ExplicitMemory)
 import qualified Futhark.CodeGen.Backends.PyOpenCL as PyOpenCL
 import Futhark.Util.Options
 import Futhark.Util.Pretty (prettyText)
+import Language.Futhark.Futlib.Prelude
 
 main :: IO ()
 main = reportingIOErrors $
@@ -24,7 +25,7 @@ main = reportingIOErrors $
 
 compile :: CompilerConfig -> FilePath -> IO ()
 compile config filepath =
-  runCompilerOnProgram (futharkConfig config)
+  runCompilerOnProgram (futharkConfig config) preludeBasis
   gpuPipeline (pyCodeAction filepath config) filepath
 
 pyCodeAction :: FilePath -> CompilerConfig -> Action ExplicitMemory

--- a/src/futhark-test.hs
+++ b/src/futhark-test.hs
@@ -37,6 +37,7 @@ import Futhark.Pipeline
 import Futhark.Compiler
 import Futhark.Test
 import Futhark.Passes
+import Language.Futhark.Futlib.Prelude
 
 import Futhark.Util.Options
 
@@ -92,7 +93,7 @@ optimisedProgramMetrics pipeline program =
                    GpuPipeline ->
                      check gpuPipeline
   where check pipeline' = do
-          res <- io $ runFutharkM (runPipelineOnProgram structTestConfig pipeline' program) False
+          res <- io $ runFutharkM (runPipelineOnProgram structTestConfig preludeBasis pipeline' program) False
           case res of
             Left err ->
               throwError $ T.pack $ show err

--- a/src/futhark.hs
+++ b/src/futhark.hs
@@ -18,6 +18,7 @@ import Prelude hiding (id)
 import Futhark.Pass
 import Futhark.Actions
 import Futhark.Compiler
+import Language.Futhark.Futlib.Prelude
 import Language.Futhark.Parser (parseFuthark)
 import Futhark.Util.Options
 import Futhark.Pipeline
@@ -311,7 +312,7 @@ main = mainWithOptions newConfig commandLineOptions compile
           case futharkPipeline config of
             TypeCheck -> do
               -- No pipeline; just read the program and type check
-              (_, warnings, _, _) <- readProgram [file]
+              (_, warnings, _, _) <- readProgram preludeBasis [file]
               liftIO $ hPutStr stderr $ show warnings
             PrettyPrint -> liftIO $ do
               maybe_prog <- parseFuthark file <$> T.readFile file
@@ -319,7 +320,7 @@ main = mainWithOptions newConfig commandLineOptions compile
                 Left err  -> fail $ show err
                 Right prog-> putStrLn $ pretty prog
             Pipeline{} -> do
-              prog <- runPipelineOnProgram (futharkConfig config) id file
+              prog <- runPipelineOnProgram (futharkConfig config) preludeBasis id file
               runPolyPasses config prog
 
 runPolyPasses :: Config -> SOACS.Prog -> FutharkM ()


### PR DESCRIPTION
Any Futhark program now implicitly opens "/futlib/prelude".

Slowdown is avoided by using Template Haskell to parse and type-check
the prelude at (Haskell) compile time.

Not sure it's worth it.